### PR TITLE
Adds method for debug

### DIFF
--- a/lib/key_master.rb
+++ b/lib/key_master.rb
@@ -79,6 +79,7 @@ SOURCE
 //
 
 #import <objc/runtime.h>
+#import <Foundation/NSDictionary.h>
 #import "<%= @name %>.h"
 
 #pragma clang diagnostic push
@@ -121,6 +122,20 @@ static NSString *_podKeys<%= Digest::MD5.hexdigest(key) %>(<%= name %> *self, SE
 
 static char <%= name %>Data[<%= @data_length %>] = "<%= @data %>";
 
+- (NSString *)description
+{
+  return [@{
+<%- @keys.each do |key, value| -%>
+            @"<%= key %>": self.<%= key %>,
+<%- end -%>
+  } description];
+}
+
+- (id)debugQuickLookObject
+{
+  return [self description];
+}
+
 @end
 SOURCE
 
@@ -131,7 +146,7 @@ SOURCE
 
     def render_erb(erb)
       require 'erb'
-      ERB.new(erb).result(binding)
+      ERB.new(erb, nil, '-').result(binding)
     end
 
     def key_data_arrays


### PR DESCRIPTION
I added method `description` and `debugQuickLookObject`.
Because it is for ease of debugging.

```Objective-C
MyApplicationKeys *keys = [[MyApplicationKeys alloc] init];
NSLog(@"%@", keys);
```

```
2015-01-13 19:30:13.473 CocoapodKeysDemo[73971:3095487] {
    NetworkAPIToken = AH2ZMiraGQbyUd9GkNTNfWEdxlwXcmHciEOH;
    AnalyticsToken = 6TYKGVCn7sBSBFpwfSUCclzDoSBtEXw7;
}
```

### for example

QuickLook
![qiucklook](https://cloud.githubusercontent.com/assets/22857/5719738/7c6d9c9e-9b5e-11e4-8055-06bf04aff99f.png)

