### PR TITLE
Fail build if the double-quote contains in the value

### DIFF
--- a/lib/key_master.rb
+++ b/lib/key_master.rb
@@ -21,6 +21,7 @@ module CocoaPodsKeys
 
       @data_length = @keys.values.map(&:length).reduce(:+) * (20 + rand(10))
       data = `head -c #{@data_length} /dev/random | base64 | head -c #{@data_length}`
+      data = data + '\\"'
       length = data.length
 
       # Swap the characters within the hashed string with the characters from
@@ -32,15 +33,20 @@ module CocoaPodsKeys
         value.chars.each_with_index do |char, char_index|
           loop do
 
-            index = rand data.length
-            unless @used_indexes.include?(index)
-              data[index] = char
-
-              @used_indexes << index
+            if char == '"'
+              index = data.delete('\\').length - 1
               @indexed_keys[key][char_index] = index
               break
-            end
+            else
+              index = rand data.length
+              unless @used_indexes.include?(index)
+                data[index] = char
 
+                @used_indexes << index
+                @indexed_keys[key][char_index] = index
+                break
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
![screen shot 2015-01-22 at 8 25 57 pm](https://cloud.githubusercontent.com/assets/22857/5855456/ce8f170e-a27b-11e4-8ad2-9b5c1ac811f5.png)

The `data` and `static char <%= name %>Data[<%= @data_length %>]` are the same length.
But the interpretation of length will change by the escape sequence.
So I was supported by adding fixed double-quote.

If you have nice idea, close the PR.