### PR TITLE
@ashfurrow => Less namespace pollution

### DIFF
--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -1,35 +1,47 @@
 require 'cocoapods-core'
 
 module CocoaPodsKeys
-  include Pod::Config::Mixin
+  class << self
+    def podspec_for_current_project(spec_contents)
+      keyring = KeyringLiberator.get_keyring_named(user_options["project"]) || KeyringLiberator.get_keyring(Dir.getwd)
+      raise Informative, "Could not load keyring" unless keyring 
+      key_master = KeyMaster.new(keyring)
 
-  def podfile_for_current_project
-    config.podfile
+      spec_contents.gsub!(/%%SOURCE_FILES%%/, "#{key_master.name}.{h,m}")
+      spec_contents.gsub!(/%%PROJECT_NAME%%/, user_options["project"])
+    end
+
+    def setup
+      require 'preinstaller'
+
+      PreInstaller.new(user_options).setup
+      # Add our template podspec (needs to be remote, not local).
+      podfile.pod 'Keys', :git => 'https://github.com/ashfurrow/empty-podspec.git'
+    end
+
+    private
+
+    def podfile
+      Pod::Config.instance.podfile
+    end
+
+    def user_options
+      podfile.plugins["cocoapods-keys"]
+    end
   end
 end
 
 module Pod
   class Installer
-    include CocoaPodsKeys
-
     alias_method :install_before_cocoapods_keys!, :install!
 
     def install!
-      require 'preinstaller'
-
-      podfile = podfile_for_current_project()
-      user_options = podfile.plugins["cocoapods-keys"]
-      PreInstaller.new(user_options).setup
-
-      # Add our template podspec (needs to be remote, not local). 
-      podfile.pod 'Keys', :git => 'https://github.com/ashfurrow/empty-podspec.git'
-
+      CocoaPodsKeys.setup
       install_before_cocoapods_keys!
     end
 
     class Analyzer
       class SandboxAnalyzer
-
         alias_method :pod_state_before_cocoapods_keys, :pod_state
 
         def pod_state(pod) 
@@ -47,23 +59,12 @@ module Pod
 
   class Specification
     class << self 
-      include CocoaPodsKeys
-
       alias_method :from_string_before_cocoapods_keys, :from_string
 
       def from_string(spec_contents, path, subspec_name = nil)
         if path.to_s.include? "Keys.podspec"
-          user_options = podfile_for_current_project.plugins["cocoapods-keys"]
-
-          keyring = KeyringLiberator.get_keyring_named(user_options["project"]) || KeyringLiberator.get_keyring(Dir.getwd)
-          abort "Could not load keyring" unless keyring 
-
-          key_master = KeyMaster.new(keyring)
-
-          spec_contents.gsub!(/%%SOURCE_FILES%%/, "#{key_master.name}.{h,m}")
-          spec_contents.gsub!(/%%PROJECT_NAME%%/, user_options["project"])
+          CocoaPodsKeys.podspec_for_current_project(spec_contents)
         end
-        
         from_string_before_cocoapods_keys(spec_contents, path, subspec_name)
       end
     end


### PR DESCRIPTION
Related to https://github.com/orta/cocoapods-keys/pull/31#commitcomment-9562540

This removes the inclusion of modules into the monkey-patched core classes and thus ensuring less chance for collisions.

(This is completely untested code btw, please test it on your existing test project.)