### PR TITLE
Support for empty plugin section

### DIFF
--- a/lib/key_master.rb
+++ b/lib/key_master.rb
@@ -17,6 +17,7 @@ module CocoaPodsKeys
 
     def generate_data
 
+      return nil if @keys.empty?
       # Generate a base64 hash string that is ~25 times the length of all keys
 
       @data_length = @keys.values.map(&:length).reduce(:+) * (20 + rand(10))

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -3,12 +3,14 @@ require 'cocoapods-core'
 module CocoaPodsKeys
   class << self
     def podspec_for_current_project(spec_contents)
-      keyring = KeyringLiberator.get_keyring_named(user_options["project"]) || KeyringLiberator.get_keyring(Dir.getwd)
+      local_user_options = user_options || {}
+      project = local_user_options.fetch("project", CocoaPodsKeys::NameWhisperer.get_project_name)
+      keyring = KeyringLiberator.get_keyring_named(project) || KeyringLiberator.get_keyring(Dir.getwd)
       raise Informative, "Could not load keyring" unless keyring 
       key_master = KeyMaster.new(keyring)
 
       spec_contents.gsub!(/%%SOURCE_FILES%%/, "#{key_master.name}.{h,m}")
-      spec_contents.gsub!(/%%PROJECT_NAME%%/, user_options["project"])
+      spec_contents.gsub!(/%%PROJECT_NAME%%/, project)
     end
 
     def setup

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -11,12 +11,10 @@ module CocoaPodsKeys
 
       options = @user_options || {}
       current_dir = Dir.getwd
-      project = options.fetch('project', nil)
+      project = options.fetch('project', CocoaPodsKeys::NameWhisperer.get_project_name)
       keyring = KeyringLiberator.get_keyring_named(project) || KeyringLiberator.get_keyring(current_dir)
-      unless keyring
-        name = project || CocoaPodsKeys::NameWhisperer.get_project_name
-        keyring = CocoaPodsKeys::Keyring.new(name, current_dir, [])
-      end
+
+      keyring = CocoaPodsKeys::Keyring.new(name, current_dir, []) unless keyring
       
       data = keyring.keychain_data
       has_shown_intro = false


### PR DESCRIPTION
Addresses the crashes that happens when there is no "plugin 'cocoapods-keys'" present in the Podfile.

More specifically, the backtrace I was getting was:
```
NoMethodError - undefined method `[]' for nil:NilClass
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-keys-1.0.1/lib/plugin.rb:6:in `podspec_for_current_project'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-keys-1.0.1/lib/plugin.rb:66:in `from_string'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-core-0.36.0/lib/cocoapods-core/specification.rb:536:in `from_file'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/sandbox.rb:212:in `block in specification'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/sandbox.rb:212:in `chdir'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/sandbox.rb:212:in `specification'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/installer/analyzer.rb:361:in `block in dependencies_to_fetch'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/installer/analyzer.rb:360:in `select'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/installer/analyzer.rb:360:in `dependencies_to_fetch'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/installer/analyzer.rb:321:in `fetch_external_sources'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/installer/analyzer.rb:57:in `analyze'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:189:in `analyze'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:111:in `block in resolve_dependencies'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/user_interface.rb:49:in `section'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:110:in `resolve_dependencies'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/installer.rb:90:in `install!'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-keys-1.0.1/lib/plugin.rb:40:in `install!'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/command/project.rb:71:in `run_install_with_update'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/command/project.rb:101:in `run'
/Users/dbarden/.gem/ruby/2.1.2/gems/claide-0.8.1/lib/claide/command.rb:312:in `run'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/lib/cocoapods/command.rb:46:in `run'
/Users/dbarden/.gem/ruby/2.1.2/gems/cocoapods-0.36.0/bin/pod:44:in `<top (required)>'
/Users/dbarden/.gem/ruby/2.1.2/bin/pod:23:in `load'
/Users/dbarden/.gem/ruby/2.1.2/bin/pod:23:in `<main>'
```

Let me know if these changes make sense. I tried to test the best way I can to ensure that I didn't break anything, but you never know :)