### PR TITLE
@orta => Fixes problems with non-defined keys

### DIFF
--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -1,7 +1,7 @@
 module CocoaPodsKeys
   class PreInstaller
     def initialize(user_options)
-      @options = user_options
+      @user_options = user_options
     end
 
     def setup
@@ -14,8 +14,8 @@ module CocoaPodsKeys
       project = options.fetch('project', CocoaPodsKeys::NameWhisperer.get_project_name)
       keyring = KeyringLiberator.get_keyring_named(project) || KeyringLiberator.get_keyring(current_dir)
 
-      keyring = CocoaPodsKeys::Keyring.new(name, current_dir, []) unless keyring
-      
+      keyring = CocoaPodsKeys::Keyring.new(project, current_dir, []) unless keyring
+
       data = keyring.keychain_data
       has_shown_intro = false
       keys = options.fetch("keys", [])


### PR DESCRIPTION
There were two problems causing the issue. First, during `PreInstaller` initialization, we were assigning to an instance variable that was never read from, due to a problem in [this commit](https://github.com/orta/cocoapods-keys/commit/a0af25643c00687149708095b21a7f59cdd2dbe7#diff-94f3f33afc788f0a2a651f67e55ef6c6R12). In a separate, but related [commit](https://github.com/orta/cocoapods-keys/commit/4ad5a07f2b86534f0746910bf05ebd5cdcce12f9#diff-94f3f33afc788f0a2a651f67e55ef6c6R17), we changed a local variable's setup to use the `project` variable instead of the (now deleted) `name` variable, but still used `name` later on.

As @orta [mentioned](https://github.com/orta/cocoapods-keys/pull/41#issuecomment-78383660), we're getting to the size that a test suite is going to help catch these kinds of problems before they ship. I'm not really sure how to start that process, but if someone were to point me in the right direction, I can take a stab at it. /cc @dbarden 

Fixes #42.