### PR TITLE
Escape backslashes and double-quotes in payload.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 before_script:
 - env RACK_ENV=test bundle exec rake spec
-install: bundle install --deployment --without development production
+install: bundle install --deployment

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-language: ruby
-before_script:
-- env RACK_ENV=test bundle exec rake spec
+language: objective-c
 install: bundle install --deployment
+script: bundle exec rake spec

--- a/spec/key_master_spec.rb
+++ b/spec/key_master_spec.rb
@@ -24,7 +24,21 @@ describe CocoaPodsKeys::KeyMaster do
     keymaster = described_class.new(keyring, Time.new(2015, 3, 11))
     expect(validate_syntax(keymaster)).to eq(true)
   end
-  
+
+  it "should escape backslashes" do
+    keyring = double("Keyring", keychain_data: [], code_name: "Fake")
+    keymaster = described_class.new(keyring, Time.new(2015, 3, 11))
+    keymaster.instance_variable_set(:@data, '\4')
+    expect(keymaster.generate_implementation).to include('"\\\4"')
+  end
+
+  it "should escape double-quotes" do
+    keyring = double("Keyring", keychain_data: [], code_name: "Fake")
+    keymaster = described_class.new(keyring, Time.new(2015, 3, 11))
+    keymaster.instance_variable_set(:@data, '"')
+    expect(keymaster.generate_implementation).to include('"\\""')
+  end
+
   def validate_syntax(keymaster)
     # write out the interface and the implementation to temp files
     Dir.mktmpdir do |dir|

--- a/spec/key_master_spec.rb
+++ b/spec/key_master_spec.rb
@@ -36,7 +36,7 @@ describe CocoaPodsKeys::KeyMaster do
       IO.write(m_file, keymaster.implementation)
       # attempt to validate syntax with clang
       Dir.chdir(dir)
-      system("clang", "-fsyntax-only", m_file)
+      system(`xcrun --sdk macosx --find clang`.strip, "-fsyntax-only", m_file)
     end
   end
 end

--- a/templates/Keys.m.erb
+++ b/templates/Keys.m.erb
@@ -46,7 +46,7 @@ static NSString *_podKeys<%= Digest::MD5.hexdigest(key) %>(<%= name %> *self, SE
 }
 <% end %>
 
-static char <%= name %>Data[<%= @data_length %>] = "<%= @data %>";
+static char <%= name %>Data[<%= @data_length %>] = "<%= @data.gsub('\\', '\\\\\\').gsub('"', '\\"') if @data %>";
 
 - (NSString *)description
 {


### PR DESCRIPTION
These were causing incorrect termination of the C-string literal.

Fixes #33.

The tests aren’t the nicest and I’d have preferred to not do the payload sanitation in the ERB template, but it works and it looks like @lyricsboy is already working on cleaning that up, so I’ll wait for that first. https://github.com/orta/cocoapods-keys/issues/46