### PR TITLE
Include plugin name in UI when asking a question.

### DIFF
--- a/lib/name_whisperer.rb
+++ b/lib/name_whisperer.rb
@@ -27,7 +27,7 @@ module CocoaPodsKeys
           Pathname.new(xcodeprojects[0]).basename.to_s
         else
           error_message = (xcodeprojects.length > 1) ? "found too many" : "couldn't find any"
-          puts "Hello there, we " + error_message + " xcodeprojects. Please give a name for this project."
+          puts "CocoaPods-Keys " + error_message + " xcodeprojects. Please give a name for this project."
 
           answer = ""
           loop do

--- a/lib/name_whisperer.rb
+++ b/lib/name_whisperer.rb
@@ -27,7 +27,7 @@ module CocoaPodsKeys
           Pathname.new(xcodeprojects[0]).basename.to_s
         else
           error_message = (xcodeprojects.length > 1) ? "found too many" : "couldn't find any"
-          puts "CocoaPods-Keys " + error_message + " xcodeprojects. Please give a name for this project."
+          puts "CocoaPods-Keys " + error_message + " Xcode projects. Please give a name for this project."
 
           answer = ""
           loop do


### PR DESCRIPTION
Without it, this question lacks any context about what Xcode project something wants to know about:

```
$ pod install
Hello there, we found too many xcodeprojects. Please give a name for this project.
>
```