### PR TITLE
Fix option fetching

### DIFF
--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -4,7 +4,7 @@ module CocoaPodsKeys
   class << self
     def podspec_for_current_project(spec_contents)
       local_user_options = user_options || {}
-      project = local_user_options.fetch("project", CocoaPodsKeys::NameWhisperer.get_project_name)
+      project = local_user_options.fetch("project") { CocoaPodsKeys::NameWhisperer.get_project_name }
       keyring = KeyringLiberator.get_keyring_named(project) || KeyringLiberator.get_keyring(Dir.getwd)
       raise Pod::Informative, "Could not load keyring" unless keyring 
       key_master = KeyMaster.new(keyring)

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -28,7 +28,13 @@ module CocoaPodsKeys
     end
 
     def user_options
-      podfile.plugins["cocoapods-keys"]
+      options = podfile.plugins["cocoapods-keys"]
+      # Until CocoaPods provides a HashWithIndifferentAccess, normalize the hash keys here.
+      # See https://github.com/CocoaPods/CocoaPods/issues/3354
+      options.inject({}) do |normalized_hash, (key, value)|
+        normalized_hash[key.to_s] = value
+        normalized_hash
+      end
     end
   end
 end

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -11,7 +11,7 @@ module CocoaPodsKeys
 
       options = @user_options || {}
       current_dir = Dir.getwd
-      project = options.fetch('project', CocoaPodsKeys::NameWhisperer.get_project_name)
+      project = options.fetch('project') { CocoaPodsKeys::NameWhisperer.get_project_name }
       keyring = KeyringLiberator.get_keyring_named(project) || KeyringLiberator.get_keyring(current_dir)
 
       keyring = CocoaPodsKeys::Keyring.new(project, current_dir, []) unless keyring


### PR DESCRIPTION
This ensures that:

* it doesn’t matter if the user uses Symbol or String keys in their Podfile
* the plugin never tries to auto-detect the Xcode project (and possibly ask the user questions) if the user specifies the Xcode project