### PR TITLE
[Template] Fix double-escape of string NULL termination.

### DIFF
--- a/templates/Keys.m.erb
+++ b/templates/Keys.m.erb
@@ -35,9 +35,9 @@ static NSString *_podKeys<%= Digest::MD5.hexdigest(key) %>(<%= name %> *self, SE
 {
   <% if @indexed_keys.length > 0 %>
     <% if @indexed_keys[key].length > 0 %>
-      char cString[<%= @indexed_keys[key].length + 1 %>] = { <%= key_data_arrays[key] %>, '\\0' };
+      char cString[<%= @indexed_keys[key].length + 1 %>] = { <%= key_data_arrays[key] %>, '\0' };
     <% else %>
-      char cString[1] = { '\\0' };
+      char cString[1] = { '\0' };
     <% end %>
     return [NSString stringWithCString:cString encoding:NSUTF8StringEncoding];
   <% else %>


### PR DESCRIPTION
It was probably double-escaped because the template was first inside a Ruby source file, but since it’s in an external file this double-escape breaks the proper building of a string.