### PR TITLE
Install to path specified by project directory

### DIFF
--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -8,7 +8,7 @@ module CocoaPodsKeys
 
       PreInstaller.new(user_options).setup
       
-      keys_path = Pod::Config.instance.installation_root.to_s + "/Pods/CocoaPodsKeys/"
+      keys_path = Pod::Config.instance.installation_root + "Pods/CocoaPodsKeys/"
 
       # move our podspec in to the Pods
       `mkdir #{keys_path}` unless Dir.exists? keys_path

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -8,10 +8,12 @@ module CocoaPodsKeys
 
       PreInstaller.new(user_options).setup
       
+      keys_path = Pod::Config.instance.installation_root.to_s + "/Pods/CocoaPodsKeys/"
+
       # move our podspec in to the Pods
-      `mkdir Pods/CocoaPodsKeys` unless Dir.exists? "Pods/CocoaPodsKeys"
+      `mkdir #{keys_path}` unless Dir.exists? keys_path
       podspec_path = File.join(__dir__, "../templates", "Keys.podspec.json")
-      `cp "#{podspec_path}" Pods/CocoaPodsKeys`
+      `cp "#{podspec_path}" "#{keys_path}"`
       
       # Get all the keys
       local_user_options = user_options || {}
@@ -21,8 +23,8 @@ module CocoaPodsKeys
   
       # Create the h & m files in the same folder as the podspec
       key_master = KeyMaster.new(keyring)
-      interface_file = File.join("Pods/CocoaPodsKeys", key_master.name + '.h')
-      implementation_file = File.join("Pods/CocoaPodsKeys", key_master.name + '.m')
+      interface_file = File.join(keys_path, key_master.name + '.h')
+      implementation_file = File.join(keys_path, key_master.name + '.m')
    
       File.write(interface_file, key_master.interface)
       File.write(implementation_file, key_master.implementation)


### PR DESCRIPTION
Installing with a custom project directory:

```bash
$ bundle exec pod install --project-directory=src
mkdir: Pods: No such file or directory
cp: Pods/CocoaPodsKeys: No such file or directory

... snip ...

Errno::ENOENT - No such file or directory @ rb_sysopen - Pods/CocoaPodsKeys/MUDRammerKeys.h
/Users/jh/Dev/cocoapods-keys/lib/plugin.rb:27:in `write'
/Users/jh/Dev/cocoapods-keys/lib/plugin.rb:27:in `setup'
/Users/jh/Dev/cocoapods-keys/lib/plugin.rb:72:in `install!'
/Users/jh/Dev/MUDRammer/vendor/bundle/ruby/2.2.0/gems/cocoapods-0.37.1/lib/cocoapods/command/project.rb:71:in `run_install_with_update'
/Users/jh/Dev/MUDRammer/vendor/bundle/ruby/2.2.0/gems/cocoapods-0.37.1/lib/cocoapods/command/project.rb:101:in `run'
/Users/jh/Dev/MUDRammer/vendor/bundle/ruby/2.2.0/gems/claide-0.8.1/lib/claide/command.rb:312:in `run'
/Users/jh/Dev/MUDRammer/vendor/bundle/ruby/2.2.0/gems/cocoapods-0.37.1/lib/cocoapods/command.rb:46:in `run'
/Users/jh/Dev/MUDRammer/vendor/bundle/ruby/2.2.0/gems/cocoapods-0.37.1/bin/pod:44:in `<top (required)>'
/Users/jh/Dev/MUDRammer/vendor/bundle/ruby/2.2.0/bin/pod:23:in `load'
/Users/jh/Dev/MUDRammer/vendor/bundle/ruby/2.2.0/bin/pod:23:in `<main>'
```

I am but a ruby padawan, but this patch seems to use the correct path for my project's root directory. :sparkles: 

~~I have noticed this causes a change in `Podfile.lock`, which now uses an absolute path:~~ (Fixed this)
