### PR TITLE
Added support for a list of targets in either a 'target' or 'targets'…

### DIFF
--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -32,17 +32,26 @@ module CocoaPodsKeys
       File.write(interface_file, key_master.interface)
       File.write(implementation_file, key_master.implementation)
 
-      # Add our template podspec
-      if user_options['target']
-        # Support correct scoping for a target
-        target = podfile.root_target_definitions.flat_map(&:children).find do |target|
-          target.label == 'Pods-' + user_options['target'].to_s
-        end
+      keys_targets = user_options['target'] || user_options['targets']
 
-        if target
-          target.store_pod 'Keys', :path => keys_path.to_path
-        else
-          Pod::UI.puts "Could not find a target named '#{user_options['target']}' in your Podfile. Stopping Keys.".red
+      # Add our template podspec
+      if keys_targets
+        # Get a list of targets, even if only one was specified
+        keys_target_list = ([] << keys_targets).flatten
+
+        # Iterate through each target specified in the Keys plugin
+        keys_target_list.each do |keys_target|
+
+          # Find a matching Pod target
+          pod_target = podfile.root_target_definitions.flat_map(&:children).find do |target|
+            target.label == "Pods-#{keys_target}"
+          end
+
+          if pod_target
+            pod_target.store_pod 'Keys', :path => keys_path.to_path
+          else
+            Pod::UI.puts "Could not find a target named '#{keys_target}' in your Podfile. Stopping keys".red
+          end
         end
 
       else


### PR DESCRIPTION
Allows you to specify the following in a Podfile, with full backward compatibility for a single item `target`, the way it used to work:

```
plugin 'cocoapods-keys', {
    :project => "Comickaze",
    :targets => ["AppTarget", "XPCServiceTarget"],
    :keys => [
        "AmazonS3SecretKey",
        "CrashlyticsAPIKey",
        "FogBugzToken",
        "PaddleAPIKey"
    ]
}
```

This addresses Issue 72.