### PR TITLE
Added support for a list of targets in either a 'target' or 'targets'…

### DIFF
--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -32,9 +32,13 @@ module CocoaPodsKeys
       File.write(interface_file, key_master.interface)
       File.write(implementation_file, key_master.implementation)
 
-      keys_targets = user_options['target'] || user_options['targets']
-
       # Add our template podspec
+      add_keys_to_pods(keys_path, user_options)
+    end
+
+    def add_keys_to_pods(keys_path, options)
+      keys_targets = options['target'] || options['targets']
+
       if keys_targets
         # Get a list of targets, even if only one was specified
         keys_target_list = ([] << keys_targets).flatten

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -41,7 +41,6 @@ module CocoaPodsKeys
 
         # Iterate through each target specified in the Keys plugin
         keys_target_list.each do |keys_target|
-
           # Find a matching Pod target
           pod_target = podfile.root_target_definitions.flat_map(&:children).find do |target|
             target.label == "Pods-#{keys_target}"

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -32,17 +32,26 @@ module CocoaPodsKeys
       File.write(interface_file, key_master.interface)
       File.write(implementation_file, key_master.implementation)
 
-      # Add our template podspec
-      if user_options['target']
-        # Support correct scoping for a target
-        target = podfile.root_target_definitions.flat_map(&:children).find do |target|
-          target.label == 'Pods-' + user_options['target'].to_s
-        end
+      keys_targets = user_options['target'] || user_options['targets']
 
-        if target
-          target.store_pod 'Keys', :path => keys_path.to_path
-        else
-          Pod::UI.puts "Could not find a target named '#{user_options['target']}' in your Podfile. Stopping Keys.".red
+      # Add our template podspec
+      if keys_targets
+        # Get a list of targets, even if only one was specified
+        keys_target_list = ([] << keys_targets).flatten
+
+        # Iterate through each target specified in the Keys plugin
+        keys_target_list.each do |keys_target|
+
+          # Find a matching Pod target
+          pod_target = podfile.root_target_definitions.flat_map(&:children).find do |target|
+            target.label == "Pods-#{keys_target}"
+          end
+
+          if pod_target
+            pod_target.store_pod 'Keys', :path => keys_path.to_path
+          else
+            Pod::UI.puts "Could not find a target named '#{keys_target}' in your Podfile. Stopping keys".red
+          end
         end
 
       else

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -50,7 +50,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetA\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetA' })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetA')
         end
       end
 
@@ -59,7 +59,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetA\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetA'] })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetA'])
         end
       end
     end
@@ -90,7 +90,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(@targetA).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetA' })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetA')
         end
       end
 
@@ -99,7 +99,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(@targetA).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetA'] })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetA'])
         end
       end
 
@@ -108,7 +108,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetB\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetB' })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetB')
         end
       end
 
@@ -117,7 +117,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetB\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetB'] })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetB'])
         end
       end
     end
@@ -150,7 +150,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).to receive(:store_pod).with('Keys', anything())
           expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetA' })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetA')
         end
       end
 
@@ -160,7 +160,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).to receive(:store_pod).with('Keys', anything())
           expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetA'] })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetA'])
         end
       end
 
@@ -170,7 +170,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
           expect(@targetB).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetB' })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetB')
         end
       end
 
@@ -180,7 +180,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
           expect(@targetB).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetB'] })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetB'])
         end
       end
 
@@ -189,7 +189,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetC\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetC' })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetC')
         end
       end
 
@@ -198,7 +198,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetC\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetC'] })
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetC'])
         end
       end
     end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -39,7 +39,7 @@ describe CocoaPodsKeys, '#plugin' do
     end
 
     it 'adds Keys to the global Pod' do
-      expect(@podfile).to receive(:pod).with('Keys', anything())
+      expect(@podfile).to receive(:pod).with('Keys', anything)
 
       CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
     end
@@ -47,7 +47,7 @@ describe CocoaPodsKeys, '#plugin' do
     ['target', 'targets'].each do |target_tag|
       context "with a non-existant target specified as a string in '#{target_tag}'" do
         it 'fails to assign the key to the tag' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetA\' in your Podfile. Stopping keys'.red)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetA')
@@ -56,7 +56,7 @@ describe CocoaPodsKeys, '#plugin' do
 
       context "with a non-existant target specified as an array in '#{target_tag}'" do
         it 'fails to assign the key to the tag' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetA\' in your Podfile. Stopping keys'.red)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetA'])
@@ -77,8 +77,8 @@ describe CocoaPodsKeys, '#plugin' do
 
     context 'with no targets specified' do
       it 'adds Keys to the global Pod' do
-        expect(@podfile).to receive(:pod).with('Keys', anything())
-        expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
+        expect(@podfile).to receive(:pod).with('Keys', anything)
+        expect(@targetA).not_to receive(:store_pod).with('Keys', anything)
 
         CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
       end
@@ -87,8 +87,8 @@ describe CocoaPodsKeys, '#plugin' do
     ['target', 'targets'].each do |target_tag|
       context "with a string specified in '#{target_tag}'" do
         it 'adds Keys to the target' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
-          expect(@targetA).to receive(:store_pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
+          expect(@targetA).to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetA')
         end
@@ -96,8 +96,8 @@ describe CocoaPodsKeys, '#plugin' do
 
       context "with an array specified in '#{target_tag}'" do
         it 'adds Keys to the target' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
-          expect(@targetA).to receive(:store_pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
+          expect(@targetA).to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetA'])
         end
@@ -105,7 +105,7 @@ describe CocoaPodsKeys, '#plugin' do
 
       context "with a non-existant target specified as a string in '#{target_tag}'" do
         it 'fails to assign the key to the tag' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetB\' in your Podfile. Stopping keys'.red)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetB')
@@ -114,7 +114,7 @@ describe CocoaPodsKeys, '#plugin' do
 
       context "with a non-existant target specified as an array in '#{target_tag}'" do
         it 'fails to assign the key to the tag' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetB\' in your Podfile. Stopping keys'.red)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetB'])
@@ -135,9 +135,9 @@ describe CocoaPodsKeys, '#plugin' do
 
     context 'with no targets specified' do
       it 'adds Keys to the global Pod' do
-        expect(@podfile).to receive(:pod).with('Keys', anything())
-        expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
-        expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
+        expect(@podfile).to receive(:pod).with('Keys', anything)
+        expect(@targetA).not_to receive(:store_pod).with('Keys', anything)
+        expect(@targetB).not_to receive(:store_pod).with('Keys', anything)
 
         CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
       end
@@ -146,9 +146,9 @@ describe CocoaPodsKeys, '#plugin' do
     ['target', 'targets'].each do |target_tag|
       context "with 'TargetA' specified as a string in '#{target_tag}'" do
         it 'adds Keys to Target A' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
-          expect(@targetA).to receive(:store_pod).with('Keys', anything())
-          expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
+          expect(@targetA).to receive(:store_pod).with('Keys', anything)
+          expect(@targetB).not_to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetA')
         end
@@ -156,9 +156,9 @@ describe CocoaPodsKeys, '#plugin' do
 
       context "with 'TargetA' specified in an array in '#{target_tag}'" do
         it 'adds Keys to Target A' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
-          expect(@targetA).to receive(:store_pod).with('Keys', anything())
-          expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
+          expect(@targetA).to receive(:store_pod).with('Keys', anything)
+          expect(@targetB).not_to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetA'])
         end
@@ -166,9 +166,9 @@ describe CocoaPodsKeys, '#plugin' do
 
       context "with 'TargetA' specified as a string in '#{target_tag}'" do
         it 'adds Keys to Target B' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
-          expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
-          expect(@targetB).to receive(:store_pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
+          expect(@targetA).not_to receive(:store_pod).with('Keys', anything)
+          expect(@targetB).to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetB')
         end
@@ -176,9 +176,9 @@ describe CocoaPodsKeys, '#plugin' do
 
       context "with 'TargetB' specified in an array in '#{target_tag}'" do
         it 'adds Keys to Target B' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
-          expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
-          expect(@targetB).to receive(:store_pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
+          expect(@targetA).not_to receive(:store_pod).with('Keys', anything)
+          expect(@targetB).to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetB'])
         end
@@ -186,7 +186,7 @@ describe CocoaPodsKeys, '#plugin' do
 
       context "with a non-existant target specified as a string in '#{target_tag}'" do
         it 'fails to assign the key to the tag' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetC\' in your Podfile. Stopping keys'.red)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetC')
@@ -195,7 +195,7 @@ describe CocoaPodsKeys, '#plugin' do
 
       context "with a non-existant target specified as an array in '#{target_tag}'" do
         it 'fails to assign the key to the tag' do
-          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@podfile).not_to receive(:pod).with('Keys', anything)
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetC\' in your Podfile. Stopping keys'.red)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetC'])

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -25,12 +25,12 @@ describe CocoaPodsKeys, '#plugin' do
     @podfile = double('Podfile')
     allow(@config).to receive(:podfile).and_return(@podfile)
 
-    @targetDefs = double('TargetDefinition')
-    @targetA = double('TargetDefinition')
-    @targetB = double('TargetDefinition')
+    @target_defs = double('TargetDefinition')
+    @target_a = double('TargetDefinition')
+    @target_b = double('TargetDefinition')
 
-    allow(@targetA).to receive(:label).and_return('Pods-TargetA')
-    allow(@targetB).to receive(:label).and_return('Pods-TargetB')
+    allow(@target_a).to receive(:label).and_return('Pods-TargetA')
+    allow(@target_b).to receive(:label).and_return('Pods-TargetB')
   end
 
   context 'with no targets defined in the Podfile' do
@@ -71,14 +71,14 @@ describe CocoaPodsKeys, '#plugin' do
       @podfile = double('Podfile')
       allow(@config).to receive(:podfile).and_return(@podfile)
 
-      allow(@podfile).to receive(:root_target_definitions).and_return([@targetDefs])
-      allow(@targetDefs).to receive(:children).and_return([@targetA])
+      allow(@podfile).to receive(:root_target_definitions).and_return([@target_defs])
+      allow(@target_defs).to receive(:children).and_return([@target_a])
     end
 
     context 'with no targets specified' do
       it 'adds Keys to the global Pod' do
         expect(@podfile).to receive(:pod).with('Keys', anything)
-        expect(@targetA).not_to receive(:store_pod).with('Keys', anything)
+        expect(@target_a).not_to receive(:store_pod).with('Keys', anything)
 
         CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
       end
@@ -88,7 +88,7 @@ describe CocoaPodsKeys, '#plugin' do
       context "with a string specified in '#{target_tag}'" do
         it 'adds Keys to the target' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything)
-          expect(@targetA).to receive(:store_pod).with('Keys', anything)
+          expect(@target_a).to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetA')
         end
@@ -97,7 +97,7 @@ describe CocoaPodsKeys, '#plugin' do
       context "with an array specified in '#{target_tag}'" do
         it 'adds Keys to the target' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything)
-          expect(@targetA).to receive(:store_pod).with('Keys', anything)
+          expect(@target_a).to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetA'])
         end
@@ -129,15 +129,15 @@ describe CocoaPodsKeys, '#plugin' do
       @podfile = double('Podfile')
       allow(@config).to receive(:podfile).and_return(@podfile)
 
-      allow(@podfile).to receive(:root_target_definitions).and_return([@targetDefs])
-      allow(@targetDefs).to receive(:children).and_return([@targetA, @targetB])
+      allow(@podfile).to receive(:root_target_definitions).and_return([@target_defs])
+      allow(@target_defs).to receive(:children).and_return([@target_a, @target_b])
     end
 
     context 'with no targets specified' do
       it 'adds Keys to the global Pod' do
         expect(@podfile).to receive(:pod).with('Keys', anything)
-        expect(@targetA).not_to receive(:store_pod).with('Keys', anything)
-        expect(@targetB).not_to receive(:store_pod).with('Keys', anything)
+        expect(@target_a).not_to receive(:store_pod).with('Keys', anything)
+        expect(@target_b).not_to receive(:store_pod).with('Keys', anything)
 
         CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
       end
@@ -147,8 +147,8 @@ describe CocoaPodsKeys, '#plugin' do
       context "with 'TargetA' specified as a string in '#{target_tag}'" do
         it 'adds Keys to Target A' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything)
-          expect(@targetA).to receive(:store_pod).with('Keys', anything)
-          expect(@targetB).not_to receive(:store_pod).with('Keys', anything)
+          expect(@target_a).to receive(:store_pod).with('Keys', anything)
+          expect(@target_b).not_to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetA')
         end
@@ -157,8 +157,8 @@ describe CocoaPodsKeys, '#plugin' do
       context "with 'TargetA' specified in an array in '#{target_tag}'" do
         it 'adds Keys to Target A' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything)
-          expect(@targetA).to receive(:store_pod).with('Keys', anything)
-          expect(@targetB).not_to receive(:store_pod).with('Keys', anything)
+          expect(@target_a).to receive(:store_pod).with('Keys', anything)
+          expect(@target_b).not_to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetA'])
         end
@@ -167,8 +167,8 @@ describe CocoaPodsKeys, '#plugin' do
       context "with 'TargetA' specified as a string in '#{target_tag}'" do
         it 'adds Keys to Target B' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything)
-          expect(@targetA).not_to receive(:store_pod).with('Keys', anything)
-          expect(@targetB).to receive(:store_pod).with('Keys', anything)
+          expect(@target_a).not_to receive(:store_pod).with('Keys', anything)
+          expect(@target_b).to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => 'TargetB')
         end
@@ -177,8 +177,8 @@ describe CocoaPodsKeys, '#plugin' do
       context "with 'TargetB' specified in an array in '#{target_tag}'" do
         it 'adds Keys to Target B' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything)
-          expect(@targetA).not_to receive(:store_pod).with('Keys', anything)
-          expect(@targetB).to receive(:store_pod).with('Keys', anything)
+          expect(@target_a).not_to receive(:store_pod).with('Keys', anything)
+          expect(@target_b).to receive(:store_pod).with('Keys', anything)
 
           CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), target_tag => ['TargetB'])
         end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -44,7 +44,7 @@ describe CocoaPodsKeys, '#plugin' do
       CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
     end
 
-    ['target', 'targets'].each do |target_tag|
+    %w(target targets).each do |target_tag|
       context "with a non-existant target specified as a string in '#{target_tag}'" do
         it 'fails to assign the key to the tag' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything)
@@ -84,7 +84,7 @@ describe CocoaPodsKeys, '#plugin' do
       end
     end
 
-    ['target', 'targets'].each do |target_tag|
+    %w(target targets).each do |target_tag|
       context "with a string specified in '#{target_tag}'" do
         it 'adds Keys to the target' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything)
@@ -143,7 +143,7 @@ describe CocoaPodsKeys, '#plugin' do
       end
     end
 
-    ['target', 'targets'].each do |target_tag|
+    %w(target targets).each do |target_tag|
       context "with 'TargetA' specified as a string in '#{target_tag}'" do
         it 'adds Keys to Target A' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything)

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -41,7 +41,7 @@ describe CocoaPodsKeys, '#plugin' do
     it "adds Keys to the global Pod" do
       expect(@podfile).to receive(:pod).with("Keys", anything())
 
-      CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {})
+      CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
     end
 
     ["target", "targets"].each do |target_tag|
@@ -50,7 +50,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with("Keys", anything())
           expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetA' in your Podfile. Stopping keys".red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetA"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetA"})
         end
       end
 
@@ -59,7 +59,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with("Keys", anything())
           expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetA' in your Podfile. Stopping keys".red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetA"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetA"]})
         end
       end
     end
@@ -80,7 +80,7 @@ describe CocoaPodsKeys, '#plugin' do
         expect(@podfile).to receive(:pod).with("Keys", anything())
         expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
 
-        CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {})
+        CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
       end
     end
 
@@ -90,7 +90,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with("Keys", anything())
           expect(@targetA).to receive(:store_pod).with("Keys", anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetA"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetA"})
         end
       end
 
@@ -99,7 +99,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with("Keys", anything())
           expect(@targetA).to receive(:store_pod).with("Keys", anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetA"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetA"]})
         end
       end
 
@@ -108,7 +108,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with("Keys", anything())
           expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetB' in your Podfile. Stopping keys".red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetB"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetB"})
         end
       end
 
@@ -117,7 +117,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with("Keys", anything())
           expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetB' in your Podfile. Stopping keys".red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetB"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetB"]})
         end
       end
     end
@@ -139,7 +139,7 @@ describe CocoaPodsKeys, '#plugin' do
         expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
         expect(@targetB).not_to receive(:store_pod).with("Keys", anything())
 
-        CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {})
+        CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
       end
     end
 
@@ -150,7 +150,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).to receive(:store_pod).with("Keys", anything())
           expect(@targetB).not_to receive(:store_pod).with("Keys", anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetA"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetA"})
         end
       end
 
@@ -160,7 +160,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).to receive(:store_pod).with("Keys", anything())
           expect(@targetB).not_to receive(:store_pod).with("Keys", anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetA"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetA"]})
         end
       end
 
@@ -170,7 +170,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
           expect(@targetB).to receive(:store_pod).with("Keys", anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetB"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetB"})
         end
       end
 
@@ -180,7 +180,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
           expect(@targetB).to receive(:store_pod).with("Keys", anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetB"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetB"]})
         end
       end
 
@@ -189,7 +189,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with("Keys", anything())
           expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetC' in your Podfile. Stopping keys".red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetC"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetC"})
         end
       end
 
@@ -198,7 +198,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with("Keys", anything())
           expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetC' in your Podfile. Stopping keys".red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetC"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetC"]})
         end
       end
     end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'cocoapods'
 require 'cocoapods-core'
 require 'plugin'
-#
+
 # include Pod
 #
 # describe Installer do
@@ -12,3 +12,195 @@ require 'plugin'
 #   end
 #
 # end
+
+RSpec.configure do |config|
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end
+
+describe CocoaPodsKeys, '#plugin' do
+  before(:each) do
+    @config = Pod::Config.instance
+    @podfile = double("Podfile")
+    allow(@config).to receive(:podfile).and_return(@podfile)
+
+    @targetDefs = double("TargetDefinition")
+    @targetA = double("TargetDefinition")
+    @targetB = double("TargetDefinition")
+
+    allow(@targetA).to receive(:label).and_return("Pods-TargetA")
+    allow(@targetB).to receive(:label).and_return("Pods-TargetB")
+  end
+
+  context "with no targets defined in the Podfile" do
+    before(:each) do
+      allow(@podfile).to receive(:root_target_definitions).and_return([])
+    end
+
+    it "adds Keys to the global Pod" do
+      expect(@podfile).to receive(:pod).with("Keys", anything())
+
+      CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {})
+    end
+
+    ["target", "targets"].each do |target_tag|
+      context "with a non-existant target specified as a string in '#{target_tag}'" do
+        it "fails to assign the key to the tag" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetA' in your Podfile. Stopping keys".red)
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetA"})
+        end
+      end
+
+      context "with a non-existant target specified as an array in '#{target_tag}'" do
+        it "fails to assign the key to the tag" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetA' in your Podfile. Stopping keys".red)
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetA"]})
+        end
+      end
+    end
+  end
+
+  context "with a single target defined in the Podfile" do
+    before(:each) do
+      @config = Pod::Config.instance
+      @podfile = double("Podfile")
+      allow(@config).to receive(:podfile).and_return(@podfile)
+
+      allow(@podfile).to receive(:root_target_definitions).and_return([@targetDefs])
+      allow(@targetDefs).to receive(:children).and_return([@targetA])
+    end
+
+    context "with no targets specified" do
+      it "adds Keys to the global Pod" do
+        expect(@podfile).to receive(:pod).with("Keys", anything())
+        expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
+
+        CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {})
+      end
+    end
+
+    ["target", "targets"].each do |target_tag|
+      context "with a string specified in '#{target_tag}'" do
+        it "adds Keys to the target" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(@targetA).to receive(:store_pod).with("Keys", anything())
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetA"})
+        end
+      end
+
+      context "with an array specified in '#{target_tag}'" do
+        it "adds Keys to the target" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(@targetA).to receive(:store_pod).with("Keys", anything())
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetA"]})
+        end
+      end
+
+      context "with a non-existant target specified as a string in '#{target_tag}'" do
+        it "fails to assign the key to the tag" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetB' in your Podfile. Stopping keys".red)
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetB"})
+        end
+      end
+
+      context "with a non-existant target specified as an array in '#{target_tag}'" do
+        it "fails to assign the key to the tag" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetB' in your Podfile. Stopping keys".red)
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetB"]})
+        end
+      end
+    end
+  end
+
+  context "with two targets defined in the Podfile" do
+    before(:each) do
+      @config = Pod::Config.instance
+      @podfile = double("Podfile")
+      allow(@config).to receive(:podfile).and_return(@podfile)
+
+      allow(@podfile).to receive(:root_target_definitions).and_return([@targetDefs])
+      allow(@targetDefs).to receive(:children).and_return([@targetA, @targetB])
+    end
+
+    context "with no targets specified" do
+      it "adds Keys to the global Pod" do
+        expect(@podfile).to receive(:pod).with("Keys", anything())
+        expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
+        expect(@targetB).not_to receive(:store_pod).with("Keys", anything())
+
+        CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {})
+      end
+    end
+
+    ["target", "targets"].each do |target_tag|
+      context "with 'TargetA' specified as a string in '#{target_tag}'" do
+        it "adds Keys to Target A" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(@targetA).to receive(:store_pod).with("Keys", anything())
+          expect(@targetB).not_to receive(:store_pod).with("Keys", anything())
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetA"})
+        end
+      end
+
+      context "with 'TargetA' specified in an array in '#{target_tag}'" do
+        it "adds Keys to Target A" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(@targetA).to receive(:store_pod).with("Keys", anything())
+          expect(@targetB).not_to receive(:store_pod).with("Keys", anything())
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetA"]})
+        end
+      end
+
+      context "with 'TargetA' specified as a string in '#{target_tag}'" do
+        it "adds Keys to Target B" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
+          expect(@targetB).to receive(:store_pod).with("Keys", anything())
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetB"})
+        end
+      end
+
+      context "with 'TargetB' specified in an array in '#{target_tag}'" do
+        it "adds Keys to Target B" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
+          expect(@targetB).to receive(:store_pod).with("Keys", anything())
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetB"]})
+        end
+      end
+
+      context "with a non-existant target specified as a string in '#{target_tag}'" do
+        it "fails to assign the key to the tag" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetC' in your Podfile. Stopping keys".red)
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => "TargetC"})
+        end
+      end
+
+      context "with a non-existant target specified as an array in '#{target_tag}'" do
+        it "fails to assign the key to the tag" do
+          expect(@podfile).not_to receive(:pod).with("Keys", anything())
+          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetC' in your Podfile. Stopping keys".red)
+
+          CocoaPodsKeys.add_keys_to_pods(Pathname.pwd + 'Pods/CocoaPodsKeys/', {target_tag => ["TargetC"]})
+        end
+      end
+    end
+  end
+end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -22,183 +22,183 @@ end
 describe CocoaPodsKeys, '#plugin' do
   before(:each) do
     @config = Pod::Config.instance
-    @podfile = double("Podfile")
+    @podfile = double('Podfile')
     allow(@config).to receive(:podfile).and_return(@podfile)
 
-    @targetDefs = double("TargetDefinition")
-    @targetA = double("TargetDefinition")
-    @targetB = double("TargetDefinition")
+    @targetDefs = double('TargetDefinition')
+    @targetA = double('TargetDefinition')
+    @targetB = double('TargetDefinition')
 
-    allow(@targetA).to receive(:label).and_return("Pods-TargetA")
-    allow(@targetB).to receive(:label).and_return("Pods-TargetB")
+    allow(@targetA).to receive(:label).and_return('Pods-TargetA')
+    allow(@targetB).to receive(:label).and_return('Pods-TargetB')
   end
 
-  context "with no targets defined in the Podfile" do
+  context 'with no targets defined in the Podfile' do
     before(:each) do
       allow(@podfile).to receive(:root_target_definitions).and_return([])
     end
 
-    it "adds Keys to the global Pod" do
-      expect(@podfile).to receive(:pod).with("Keys", anything())
+    it 'adds Keys to the global Pod' do
+      expect(@podfile).to receive(:pod).with('Keys', anything())
 
       CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
     end
 
-    ["target", "targets"].each do |target_tag|
+    ['target', 'targets'].each do |target_tag|
       context "with a non-existant target specified as a string in '#{target_tag}'" do
-        it "fails to assign the key to the tag" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetA' in your Podfile. Stopping keys".red)
+        it 'fails to assign the key to the tag' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetA\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetA"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetA'})
         end
       end
 
       context "with a non-existant target specified as an array in '#{target_tag}'" do
-        it "fails to assign the key to the tag" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetA' in your Podfile. Stopping keys".red)
+        it 'fails to assign the key to the tag' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetA\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetA"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetA']})
         end
       end
     end
   end
 
-  context "with a single target defined in the Podfile" do
+  context 'with a single target defined in the Podfile' do
     before(:each) do
       @config = Pod::Config.instance
-      @podfile = double("Podfile")
+      @podfile = double('Podfile')
       allow(@config).to receive(:podfile).and_return(@podfile)
 
       allow(@podfile).to receive(:root_target_definitions).and_return([@targetDefs])
       allow(@targetDefs).to receive(:children).and_return([@targetA])
     end
 
-    context "with no targets specified" do
-      it "adds Keys to the global Pod" do
-        expect(@podfile).to receive(:pod).with("Keys", anything())
-        expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
+    context 'with no targets specified' do
+      it 'adds Keys to the global Pod' do
+        expect(@podfile).to receive(:pod).with('Keys', anything())
+        expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
 
         CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
       end
     end
 
-    ["target", "targets"].each do |target_tag|
+    ['target', 'targets'].each do |target_tag|
       context "with a string specified in '#{target_tag}'" do
-        it "adds Keys to the target" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(@targetA).to receive(:store_pod).with("Keys", anything())
+        it 'adds Keys to the target' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@targetA).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetA"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetA'})
         end
       end
 
       context "with an array specified in '#{target_tag}'" do
-        it "adds Keys to the target" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(@targetA).to receive(:store_pod).with("Keys", anything())
+        it 'adds Keys to the target' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@targetA).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetA"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetA']})
         end
       end
 
       context "with a non-existant target specified as a string in '#{target_tag}'" do
-        it "fails to assign the key to the tag" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetB' in your Podfile. Stopping keys".red)
+        it 'fails to assign the key to the tag' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetB\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetB"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetB'})
         end
       end
 
       context "with a non-existant target specified as an array in '#{target_tag}'" do
-        it "fails to assign the key to the tag" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetB' in your Podfile. Stopping keys".red)
+        it 'fails to assign the key to the tag' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetB\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetB"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetB']})
         end
       end
     end
   end
 
-  context "with two targets defined in the Podfile" do
+  context 'with two targets defined in the Podfile' do
     before(:each) do
       @config = Pod::Config.instance
-      @podfile = double("Podfile")
+      @podfile = double('Podfile')
       allow(@config).to receive(:podfile).and_return(@podfile)
 
       allow(@podfile).to receive(:root_target_definitions).and_return([@targetDefs])
       allow(@targetDefs).to receive(:children).and_return([@targetA, @targetB])
     end
 
-    context "with no targets specified" do
-      it "adds Keys to the global Pod" do
-        expect(@podfile).to receive(:pod).with("Keys", anything())
-        expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
-        expect(@targetB).not_to receive(:store_pod).with("Keys", anything())
+    context 'with no targets specified' do
+      it 'adds Keys to the global Pod' do
+        expect(@podfile).to receive(:pod).with('Keys', anything())
+        expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
+        expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
 
         CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {})
       end
     end
 
-    ["target", "targets"].each do |target_tag|
+    ['target', 'targets'].each do |target_tag|
       context "with 'TargetA' specified as a string in '#{target_tag}'" do
-        it "adds Keys to Target A" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(@targetA).to receive(:store_pod).with("Keys", anything())
-          expect(@targetB).not_to receive(:store_pod).with("Keys", anything())
+        it 'adds Keys to Target A' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@targetA).to receive(:store_pod).with('Keys', anything())
+          expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetA"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetA'})
         end
       end
 
       context "with 'TargetA' specified in an array in '#{target_tag}'" do
-        it "adds Keys to Target A" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(@targetA).to receive(:store_pod).with("Keys", anything())
-          expect(@targetB).not_to receive(:store_pod).with("Keys", anything())
+        it 'adds Keys to Target A' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@targetA).to receive(:store_pod).with('Keys', anything())
+          expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetA"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetA']})
         end
       end
 
       context "with 'TargetA' specified as a string in '#{target_tag}'" do
-        it "adds Keys to Target B" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
-          expect(@targetB).to receive(:store_pod).with("Keys", anything())
+        it 'adds Keys to Target B' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
+          expect(@targetB).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetB"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetB'})
         end
       end
 
       context "with 'TargetB' specified in an array in '#{target_tag}'" do
-        it "adds Keys to Target B" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(@targetA).not_to receive(:store_pod).with("Keys", anything())
-          expect(@targetB).to receive(:store_pod).with("Keys", anything())
+        it 'adds Keys to Target B' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
+          expect(@targetB).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetB"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetB']})
         end
       end
 
       context "with a non-existant target specified as a string in '#{target_tag}'" do
-        it "fails to assign the key to the tag" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetC' in your Podfile. Stopping keys".red)
+        it 'fails to assign the key to the tag' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetC\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => "TargetC"})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetC'})
         end
       end
 
       context "with a non-existant target specified as an array in '#{target_tag}'" do
-        it "fails to assign the key to the tag" do
-          expect(@podfile).not_to receive(:pod).with("Keys", anything())
-          expect(Pod::UI).to receive(:puts).with("Could not find a target named 'TargetC' in your Podfile. Stopping keys".red)
+        it 'fails to assign the key to the tag' do
+          expect(@podfile).not_to receive(:pod).with('Keys', anything())
+          expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetC\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ["TargetC"]})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetC']})
         end
       end
     end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -50,7 +50,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetA\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetA'})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetA' })
         end
       end
 
@@ -59,7 +59,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetA\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetA']})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetA'] })
         end
       end
     end
@@ -90,7 +90,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(@targetA).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetA'})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetA' })
         end
       end
 
@@ -99,7 +99,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(@targetA).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetA']})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetA'] })
         end
       end
 
@@ -108,7 +108,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetB\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetB'})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetB' })
         end
       end
 
@@ -117,7 +117,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetB\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetB']})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetB'] })
         end
       end
     end
@@ -150,7 +150,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).to receive(:store_pod).with('Keys', anything())
           expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetA'})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetA' })
         end
       end
 
@@ -160,7 +160,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).to receive(:store_pod).with('Keys', anything())
           expect(@targetB).not_to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetA']})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetA'] })
         end
       end
 
@@ -170,7 +170,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
           expect(@targetB).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetB'})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetB' })
         end
       end
 
@@ -180,7 +180,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@targetA).not_to receive(:store_pod).with('Keys', anything())
           expect(@targetB).to receive(:store_pod).with('Keys', anything())
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetB']})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetB'] })
         end
       end
 
@@ -189,7 +189,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetC\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => 'TargetC'})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => 'TargetC' })
         end
       end
 
@@ -198,7 +198,7 @@ describe CocoaPodsKeys, '#plugin' do
           expect(@podfile).not_to receive(:pod).with('Keys', anything())
           expect(Pod::UI).to receive(:puts).with('Could not find a target named \'TargetC\' in your Podfile. Stopping keys'.red)
 
-          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), {target_tag => ['TargetC']})
+          CocoaPodsKeys.add_keys_to_pods(Pathname.new('Pods/CocoaPodsKeys/'), { target_tag => ['TargetC'] })
         end
       end
     end


### PR DESCRIPTION
Allows you to specify the following in a Podfile, with full backward compatibility for a single item `target`, the way it used to work:

```
plugin 'cocoapods-keys', {
    :project => "Comickaze",
    :targets => ["AppTarget", "XPCServiceTarget"],
    :keys => [
        "AmazonS3SecretKey",
        "CrashlyticsAPIKey",
        "FogBugzToken",
        "PaddleAPIKey"
    ]
}
```

(Issue #72)