### PR TITLE
@orta => Adds support for linting pods with cocoapods-keys installed on system.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Support for not including keys in Podfile [ashfurrow]
+
 ## 1.2.0
 
 * Support for correctly scoping Keys to a target [orta]

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -76,7 +76,8 @@ module Pod
     end
 
     def validates_for_keys
-      !Pod::Config.instance.podfile.plugins['cocoapods-keys'].nil?
+      podfile = Pod::Config.instance.podfile
+      !(podfile.nil? || podfile.plugins.nil? || podfile.plugins['cocoapods-keys'].nil?)
     end
   end
 end


### PR DESCRIPTION
Basically we're now being suuuper cautious about validating, and fail via shortcircuiting if anything goes wrong. 

Fixes #63.
Fixes #55.