### PR TITLE
Adding some documentation for swift project

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The generated Objective-C classes are stored in the `Pods/Keys` directory, so if
 
 ## Usage
 
-Using the new Plugin API in CocoaPods we can automate a lot of the fiddly bits away. You define what keys you want inside your [Podfile](https://github.com/artsy/eidolon/blob/0a9f5947914eb637fd4abf364fa3532b56da3c52/Podfile#L6-L21) and Keys will detect what keys are not yet set. If you need to specify a different project name from the target name, use the key `:target` to specify it. 
+Using the new Plugin API in CocoaPods we can automate a lot of the fiddly bits away. You define what keys you want inside your [Podfile](https://github.com/artsy/eidolon/blob/0a9f5947914eb637fd4abf364fa3532b56da3c52/Podfile#L6-L21) and Keys will detect what keys are not yet set. If you need to specify a different project name from the target name, use the key `:target` to specify it.
 
 ```
 plugin 'cocoapods-keys', {
@@ -88,6 +88,8 @@ After the next `pod install` or `pod update` keys will add a new `Keys` pod to y
 @end
 
 ```
+
+Some documentation is also available to [use cocoapods-keys in Swift projects](SWIFT_PROJECTS.md).
 
 #### Other commands
 

--- a/SWIFT_PROJECTS.md
+++ b/SWIFT_PROJECTS.md
@@ -1,0 +1,31 @@
+# Using Cocoapods-Keys in Swift projects
+
+Once you've followed the setup instructions described in the [Usage](/orta/cocoapods-keys#usage)
+section of the README, you have two choices.
+
+## Using the bridge header
+
+If you want to make your keys available to your whole project:
+
+1. Make sure you have a [bridging header](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html) already setup.
+2. In the bridging header, import the generated key file:
+```objectivec
+#import <Keys/MyApplicationKeys.h>
+```
+
+## Importing the framework
+
+If you've added the `use_frameworks!` and only want your Keys to be available in
+specific files, simply use Swift's `import` statement. The name of the generated
+module is `Keys`.
+
+```swift
+import Keys
+```
+
+## Usage
+
+```swift
+let keys = MyApplicationKeys()
+ARAnalytics.setupWithAnalytics(keys.analyticsToken)
+```


### PR DESCRIPTION
I've written some documentation to use `cocoa pods-keys` in Swift projects since I ran into some issues last night. Nothing @ashfurrow and the proper name of the module to import couldn't fix.

I saw in #65 that you preferred having this documentation in a separate file so here it is. Please let me know if the name of the file, the way it's introduced in the README and the content isn't good or clear enough.

I guess a "Troubleshooting" section would be nice as well but since I didn't encounter any major issues I wasn't sure what to write. 