### PR TITLE
This should fix the uninitialized constant reported in #81

### DIFF
--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -38,7 +38,7 @@ module CocoaPodsKeys
             break if answer.length > 0
           end
 
-          UI.puts
+          ui.puts
           args = CLAide::ARGV.new([key, answer, keyring.name])
           setter = Pod::Command::Keys::Set.new(args)
           setter.run


### PR DESCRIPTION
This commit renames `UI` to `ui`. Should fix https://github.com/orta/cocoapods-keys/issues/81.