### PR TITLE
[Paths] Fixed relative paths from installation roots

### DIFF
--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -12,7 +12,7 @@ module CocoaPodsKeys
       PreInstaller.new(user_options).setup
 
       installation_root = Pod::Config.instance.installation_root
-      keys_path = installation_root.+('Pods/CocoaPodsKeys/').relative_path_from(installation_root)
+      keys_path = installation_root.+('Pods/CocoaPodsKeys/')
 
       # move our podspec in to the Pods
       mkdir_p keys_path
@@ -34,7 +34,7 @@ module CocoaPodsKeys
       File.write(implementation_file, key_master.implementation)
 
       # Add our template podspec
-      add_keys_to_pods(keys_path, user_options)
+      add_keys_to_pods(keys_path.relative_path_from(installation_root), user_options)
     end
 
     def add_keys_to_pods(keys_path, options)


### PR DESCRIPTION
This fixes an issue introduced by #93.

A project that has its `Podfile` and other files in a `src` directory has its keys files placed improperly at `Pods/CocoaPodsKeys`, from the root of the repo, when they should be placed at `src/Pods/CocoaPodsKeys`.

Thanks to @segiddins for the fix!