### PR TITLE
[Paths] Additional project keys paths fixes

### DIFF
--- a/lib/key_master.rb
+++ b/lib/key_master.rb
@@ -10,7 +10,7 @@ module CocoaPodsKeys
     def initialize(keyring, time = Time.now)
       @time = time
       @keys = Hash[keyring.keychain_data.map { |(key, value)| [key[0].downcase + key[1..-1], value] }]
-      @name = keyring.code_name + 'Keys'
+      @name = keyring.code_name.capitalize + 'Keys'
       @used_indexes = Set.new
       @indexed_keys = {}
       @data = generate_data

--- a/lib/name_whisperer.rb
+++ b/lib/name_whisperer.rb
@@ -7,15 +7,15 @@ module CocoaPodsKeys
       if podfile
         user_xcodeproj = xcodeproj_from_podfile(podfile)
       end
-      user_xcodeproj ||= search_folders_for_xcodeproj
-      user_xcodeproj.basename('.xcodeproj')
+      user_xcodeproj || search_folders_for_xcodeproj
     end
 
     private
 
     def self.xcodeproj_from_podfile(podfile)
       unless podfile.target_definition_list.empty?
-        return podfile.target_definition_list.first.user_project_path
+        project_path = podfile.target_definition_list.first.user_project_path
+        File.basename(project_path, '.xcodeproj') if project_path
       end
     end
 
@@ -23,7 +23,7 @@ module CocoaPodsKeys
       ui = Pod::UserInterface
       xcodeprojects = Pathname.glob('**/*.xcodeproj')
       if xcodeprojects.length == 1
-        Pathname(xcodeprojects.first).basename
+        Pathname(xcodeprojects.first).basename('.xcodeproj')
       else
         error_message = (xcodeprojects.length > 1) ? 'found too many' : "couldn't find any"
         ui.puts 'CocoaPods-Keys ' + error_message + ' Xcode projects. Please give a name for this project.'

--- a/lib/pod/command/keys.rb
+++ b/lib/pod/command/keys.rb
@@ -1,6 +1,8 @@
 module Pod
   class Command
     class Keys < Command
+      include ProjectDirectory
+
       require 'pod/command/keys/list'
       require 'pod/command/keys/set'
       require 'pod/command/keys/get'


### PR DESCRIPTION
Additional fixes for project files that do not live in the root of the repo.

In particular:

- This syntax should now be allowed (and preferred?): `bundle exec pod keys --project-directory=src set [KEY] [VALUE]`
- Fixes an exception:

```bash
NoMethodError - undefined method `basename' for "Mudrammer.xcodeproj":String
/Users/distiller/MUDRammer/vendor/bundle/ruby/2.0.0/gems/cocoapods-keys-1.3.1/lib/name_whisperer.rb:11:in `get_project_name'
/Users/distiller/MUDRammer/vendor/bundle/ruby/2.0.0/gems/cocoapods-keys-1.3.1/lib/pod/command/keys/set.rb:55:in `current_keyring'
/Users/distiller/MUDRammer/vendor/bundle/ruby/2.0.0/gems/cocoapods-keys-1.3.1/lib/pod/command/keys/set.rb:41:in `run'
/Users/distiller/MUDRammer/vendor/bundle/ruby/2.0.0/gems/claide-0.8.1/lib/claide/command.rb:312:in `run'
/Users/distiller/MUDRammer/vendor/bundle/ruby/2.0.0/gems/cocoapods-0.37.2/lib/cocoapods/command.rb:46:in `run'
/Users/distiller/MUDRammer/vendor/bundle/ruby/2.0.0/gems/cocoapods-0.37.2/bin/pod:44:in `<top (required)>'
/Users/distiller/MUDRammer/vendor/bundle/ruby/2.0.0/bin/pod:23:in `load'
/Users/distiller/MUDRammer/vendor/bundle/ruby/2.0.0/bin/pod:23:in `<main>’
```
- Standardizes capitalization of file names (potentially breaking change). This resolved cocoapods-keys coming up with different names for my Keys files locally and on CircleCI.

Thanks @segiddins once again!