### PR TITLE
[WIP] Some thoughts around projects that have the same name.

### DIFF
--- a/lib/keyring.rb
+++ b/lib/keyring.rb
@@ -6,7 +6,7 @@ module CocoaPodsKeys
 
     def initialize(name, path, keys = [])
       @name = name.to_s
-      @path = path
+      @path = path.to_s
       @keys = keys
     end
 

--- a/lib/keyring.rb
+++ b/lib/keyring.rb
@@ -26,13 +26,15 @@ module CocoaPodsKeys
       'cocoapods-keys-'
     end
 
+    def keychain
+      @keychain ||= OSXKeychain.new
+    end
+
     def save(key, value)
-      keychain = OSXKeychain.new
       keychain[self.class.keychain_prefix + name, key] = value
     end
 
     def keychain_data
-      keychain = OSXKeychain.new
       Hash[
         @keys.map { |key| [key, ENV[key] || keychain[self.class.keychain_prefix + name, key]] }
       ]

--- a/lib/keyring.rb
+++ b/lib/keyring.rb
@@ -36,8 +36,24 @@ module CocoaPodsKeys
 
     def keychain_data
       Hash[
-        @keys.map { |key| [key, ENV[key] || keychain[self.class.keychain_prefix + name, key]] }
+        @keys.map { |key| [key, keychain_value(key)] }
       ]
+    end
+
+    def keychain_has_key?(key)
+      has_key = !keychain_value(key).nil?
+
+      if has_key && !@keys.include?(key)
+        @keys << key
+      elsif !has_key && @keys.include?(key)
+        @keys.delete(key)
+      end
+
+      has_key
+    end
+
+    def keychain_value(key)
+      ENV[key] || keychain[self.class.keychain_prefix + name, key]
     end
 
     def camel_cased_keys

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -21,11 +21,15 @@ module CocoaPodsKeys
     end
 
     def self.get_keyring_named(name)
-      get_all_keyrings.find { |k| k.name == name }
+      get_all_keyrings.find { |k| k.name == name && k.path == Dir.getwd }
     end
 
     def self.save_keyring(keyring)
       keys_dir.mkpath
+
+      if get_keyring_named(keyring)
+        puts "About to create a duplicate keyring file for project #{keyring.name.green}"
+      end
 
       yaml_path_for_path(keyring.path).open('w') { |f| f.write(YAML.dump(keyring.to_hash)) }
     end

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -24,6 +24,15 @@ module CocoaPodsKeys
       get_all_keyrings.find { |k| k.name == name }
     end
 
+    def self.get_current_keyring(name, cwd)
+      found_by_name = name && get_all_keyrings.find { |k| k.name == name && k.path == cwd.to_s }
+      found_by_name || KeyringLiberator.get_keyring(cwd)
+    end
+
+    def self.get_all_keyrings_named(name)
+      get_all_keyrings.find_all { |k| k.name == name }
+    end
+
     def self.save_keyring(keyring)
       keys_dir.mkpath
 

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -40,6 +40,7 @@ module CocoaPodsKeys
       if existing && yaml_path_for_path(existing.path) != yaml_path_for_path(keyring.path)
         ui = Pod::UserInterface
         ui.puts "About to create a duplicate keyring file for project #{keyring.name.green}"
+        ui.puts "Entries in your Apple Keychain will be shared between both projects."
         ui.puts "\nPress enter to continue, or `ctrl + c` to cancel"
         ui.gets
       end

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -21,7 +21,7 @@ module CocoaPodsKeys
     end
 
     def self.get_keyring_named(name)
-      get_all_keyrings.find { |k| k.name == name && k.path == Dir.getwd }
+      get_all_keyrings.find { |k| k.name == name }
     end
 
     def self.save_keyring(keyring)

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -36,7 +36,8 @@ module CocoaPodsKeys
     def self.save_keyring(keyring)
       keys_dir.mkpath
 
-      if get_keyring_named(keyring)
+      existing = get_keyring_named(keyring.name)
+      if existing && yaml_path_for_path(existing.path) != yaml_path_for_path(keyring.path)
         ui = Pod::UserInterface
         ui.puts "About to create a duplicate keyring file for project #{keyring.name.green}"
         ui.puts "\nPress enter to continue, or `ctrl + c` to cancel"

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -28,7 +28,10 @@ module CocoaPodsKeys
       keys_dir.mkpath
 
       if get_keyring_named(keyring)
-        puts "About to create a duplicate keyring file for project #{keyring.name.green}"
+        ui = Pod::UserInterface
+        ui.puts "About to create a duplicate keyring file for project #{keyring.name.green}"
+        ui.puts "\nPress enter to continue, or `ctrl + c` to cancel"
+        ui.gets
       end
 
       yaml_path_for_path(keyring.path).open('w') { |f| f.write(YAML.dump(keyring.to_hash)) }

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -33,19 +33,21 @@ module CocoaPodsKeys
       get_all_keyrings.find_all { |k| k.name == name }
     end
 
-    def self.save_keyring(keyring)
-      keys_dir.mkpath
-
+    def self.prompt_if_already_existing(keyring)
       keyrings = get_all_keyrings_named(keyring.name)
-      already_exists = File.exists?(yaml_path_for_path(keyring.path))
-      if !already_exists && keyrings.any? { |existing_keyring| File.exists?(yaml_path_for_path(existing_keyring.path)) }
+      already_exists = File.exist?(yaml_path_for_path(keyring.path))
+      if !already_exists && keyrings.any? { |existing_keyring| File.exist?(yaml_path_for_path(existing_keyring.path)) }
         ui = Pod::UserInterface
         ui.puts "About to create a duplicate keyring file for project #{keyring.name.green}"
-        ui.puts "Entries in your Apple Keychain will be shared between both projects."
+        ui.puts 'Entries in your Apple Keychain will be shared between both projects.'
         ui.puts "\nPress enter to continue, or `ctrl + c` to cancel"
         ui.gets
       end
+    end
 
+    def self.save_keyring(keyring)
+      keys_dir.mkpath
+      prompt_if_already_existing(keyring)
       yaml_path_for_path(keyring.path).open('w') { |f| f.write(YAML.dump(keyring.to_hash)) }
     end
 

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -36,8 +36,9 @@ module CocoaPodsKeys
     def self.save_keyring(keyring)
       keys_dir.mkpath
 
-      existing = get_keyring_named(keyring.name)
-      if existing && yaml_path_for_path(existing.path) != yaml_path_for_path(keyring.path)
+      keyrings = get_all_keyrings_named(keyring.name)
+      already_exists = File.exists?(yaml_path_for_path(keyring.path))
+      if !already_exists && keyrings.any? { |existing_keyring| File.exists?(yaml_path_for_path(existing_keyring.path)) }
         ui = Pod::UserInterface
         ui.puts "About to create a duplicate keyring file for project #{keyring.name.green}"
         ui.puts "Entries in your Apple Keychain will be shared between both projects."

--- a/lib/name_whisperer.rb
+++ b/lib/name_whisperer.rb
@@ -21,7 +21,7 @@ module CocoaPodsKeys
 
     def self.search_folders_for_xcodeproj
       ui = Pod::UserInterface
-      xcodeprojects = Pathname.glob('**/*.xcodeproj')
+      xcodeprojects = Pathname.glob('**/*.xcodeproj').reject { |path| path.to_s.end_with?('Pods/Pods.xcodeproj') }
       if xcodeprojects.length == 1
         Pathname(xcodeprojects.first).basename('.xcodeproj')
       else

--- a/lib/plugin.rb
+++ b/lib/plugin.rb
@@ -25,8 +25,7 @@ module CocoaPodsKeys
       local_user_options = user_options || {}
       project = local_user_options.fetch('project') { CocoaPodsKeys::NameWhisperer.get_project_name }
 
-      keyring = KeyringLiberator.get_keyring_named(project) ||
-        KeyringLiberator.get_keyring(Dir.getwd) ||
+      keyring = KeyringLiberator.get_current_keyring(project, Dir.getwd) ||
         Keyring.new(project, Dir.getwd, local_user_options['keys'])
 
       raise Pod::Informative, 'Could not load keyring' unless keyring

--- a/lib/pod/command/keys.rb
+++ b/lib/pod/command/keys.rb
@@ -16,6 +16,11 @@ module Pod
 
       self.abstract_command = true
       self.default_subcommand = 'list'
+
+      def get_current_keyring
+        current_dir = Pathname.pwd
+        CocoaPodsKeys::KeyringLiberator.get_current_keyring(@project_name, current_dir)
+      end
     end
   end
 end

--- a/lib/pod/command/keys.rb
+++ b/lib/pod/command/keys.rb
@@ -17,9 +17,16 @@ module Pod
       self.abstract_command = true
       self.default_subcommand = 'list'
 
+      def create_keyring
+        current_dir = Pathname.pwd
+        name = @project_name || CocoaPodsKeys::NameWhisperer.get_project_name
+        CocoaPodsKeys::Keyring.new(name, current_dir, [])
+      end
+
       def get_current_keyring
         current_dir = Pathname.pwd
-        CocoaPodsKeys::KeyringLiberator.get_current_keyring(@project_name, current_dir)
+        project = @project_name || CocoaPodsKeys::NameWhisperer.get_project_name
+        CocoaPodsKeys::KeyringLiberator.get_current_keyring(project, current_dir)
       end
     end
   end

--- a/lib/pod/command/keys/get.rb
+++ b/lib/pod/command/keys/get.rb
@@ -35,8 +35,8 @@ module Pod
           end
 
           if keyring.keys.include? @key_name
-            data = keyring.keychain_data
-            UI.puts data[@key_name]
+            data = keyring.keychain_value(@key_name)
+            UI.puts data
           else
             raise Informative, 'Could not find value'
           end

--- a/lib/pod/command/keys/get.rb
+++ b/lib/pod/command/keys/get.rb
@@ -41,15 +41,6 @@ module Pod
             raise Informative, 'Could not find value'
           end
         end
-
-        def get_current_keyring
-          current_dir = Pathname.pwd
-          keyring = CocoaPodsKeys::KeyringLiberator.get_keyring current_dir
-          if !keyring && @project_name
-            return CocoaPodsKeys::KeyringLiberator.get_keyring_named @project_name
-          end
-          keyring
-        end
       end
     end
   end

--- a/lib/pod/command/keys/rm.rb
+++ b/lib/pod/command/keys/rm.rb
@@ -55,15 +55,6 @@ module Pod
             raise Informative, "Could not find key named #{@key_name}."
           end
         end
-
-        def get_current_keyring
-          current_dir = Pathname.pwd
-          keyring = CocoaPodsKeys::KeyringLiberator.get_keyring current_dir
-          if !keyring && @project_name
-            return CocoaPodsKeys::KeyringLiberator.get_keyring_named @project_name
-          end
-          keyring
-        end
       end
     end
   end

--- a/lib/pod/command/keys/set.rb
+++ b/lib/pod/command/keys/set.rb
@@ -38,25 +38,13 @@ module Pod
           # set a key to a folder id in ~/.cocoapods/keys
           # info "Saving into the keychain."
 
-          keyring = current_keyring
+          keyring = get_current_keyring || create_keyring
           keyring.keys << @key_name.tr('-', '_')
           CocoaPodsKeys::KeyringLiberator.save_keyring keyring
 
           keyring.save @key_name, @key_value
 
           UI.puts "Saved #{@key_name} to #{keyring.name}." unless config.silent?
-        end
-
-        def current_keyring
-          current_dir = Pathname.pwd
-          keyring = CocoaPodsKeys::KeyringLiberator.get_keyring current_dir
-
-          unless keyring
-            name = @project_name || CocoaPodsKeys::NameWhisperer.get_project_name
-            keyring = CocoaPodsKeys::Keyring.new(name, current_dir, [])
-          end
-
-          keyring
         end
       end
     end

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -17,7 +17,21 @@ module CocoaPodsKeys
       options = @user_options || {}
       current_dir = Pathname.pwd
       project = options.fetch('project') { CocoaPodsKeys::NameWhisperer.get_project_name }
-      keyring = KeyringLiberator.get_keyring_named(project) || KeyringLiberator.get_keyring(current_dir)
+
+      keyring = KeyringLiberator.get_current_keyring(project, current_dir)
+
+      unless keyring
+        keyrings = KeyringLiberator.get_all_keyrings_named(project)
+        if keyrings.count > 1 && keyring.nil?
+          ui.puts "Found multiple keyrings for project #{project.inspect}, but"
+          ui.puts "no match found for current path (#{current_dir}):"
+          keyrings.each do |found_keyring|
+            ui.puts "- #{found_keyring.path}"
+          end
+          ui.puts "\nPress enter to create a new keyring, or `ctrl + c` to cancel"
+          ui.gets
+        end
+      end
 
       existing_keyring = !keyring.nil?
       keyring = CocoaPodsKeys::Keyring.new(project, current_dir, []) unless keyring

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -21,16 +21,7 @@ module CocoaPodsKeys
       keyring = KeyringLiberator.get_current_keyring(project, current_dir)
 
       unless keyring
-        keyrings = KeyringLiberator.get_all_keyrings_named(project)
-        if keyrings.count > 1 && keyring.nil?
-          ui.puts "Found multiple keyrings for project #{project.inspect}, but"
-          ui.puts "no match found for current path (#{current_dir}):"
-          keyrings.each do |found_keyring|
-            ui.puts "- #{found_keyring.path}"
-          end
-          ui.puts "\nPress enter to create a new keyring, or `ctrl + c` to cancel"
-          ui.gets
-        end
+        check_for_multiple_keyrings(project)
       end
 
       existing_keyring = !keyring.nil?
@@ -62,6 +53,20 @@ module CocoaPodsKeys
       end
 
       existing_keyring || !keys.empty?
+    end
+
+    def check_for_multiple_keyrings(project)
+      ui = Pod::UserInterface
+      keyrings = KeyringLiberator.get_all_keyrings_named(project)
+      if keyrings.count > 1 && keyring.nil?
+        ui.puts "Found multiple keyrings for project #{project.inspect}, but"
+        ui.puts "no match found for current path (#{current_dir}):"
+        keyrings.each do |found_keyring|
+          ui.puts "- #{found_keyring.path}"
+        end
+        ui.puts "\nPress enter to create a new keyring, or `ctrl + c` to cancel"
+        ui.gets
+      end
     end
   end
 end

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -50,6 +50,7 @@ module CocoaPodsKeys
           setter.run
         end
       end
+      CocoaPodsKeys::KeyringLiberator.save_keyring(keyring)
 
       existing_keyring || !keys.empty?
     end

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -27,11 +27,10 @@ module CocoaPodsKeys
       existing_keyring = !keyring.nil?
       keyring = CocoaPodsKeys::Keyring.new(project, current_dir, []) unless keyring
 
-      data = keyring.keychain_data
       has_shown_intro = false
       keys = options.fetch('keys', [])
       keys.each do |key|
-        unless ENV[key] || data.keys.include?(key)
+        unless keyring.keychain_has_key?(key)
           unless has_shown_intro
             ui.puts "\n CocoaPods-Keys has detected a keys mismatch for your setup."
             has_shown_intro = true

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -21,7 +21,7 @@ module CocoaPodsKeys
       keyring = KeyringLiberator.get_current_keyring(project, current_dir)
 
       unless keyring
-        check_for_multiple_keyrings(project)
+        check_for_multiple_keyrings(project, current_dir)
       end
 
       existing_keyring = !keyring.nil?
@@ -55,10 +55,10 @@ module CocoaPodsKeys
       existing_keyring || !keys.empty?
     end
 
-    def check_for_multiple_keyrings(project)
+    def check_for_multiple_keyrings(project, current_dir)
       ui = Pod::UserInterface
       keyrings = KeyringLiberator.get_all_keyrings_named(project)
-      if keyrings.count > 1 && keyring.nil?
+      if keyrings.count > 1
         ui.puts "Found multiple keyrings for project #{project.inspect}, but"
         ui.puts "no match found for current path (#{current_dir}):"
         keyrings.each do |found_keyring|

--- a/spec/functional_spec.rb
+++ b/spec/functional_spec.rb
@@ -29,6 +29,13 @@ describe 'CocoaPodsKeys functional tests' do
     end
   end
 
+  after :all do
+    KeyringLiberator.get_all_keyrings_named('TestProject').each do |keyring|
+      file = KeyringLiberator.yaml_path_for_path(keyring.path)
+      FileUtils.rm(file) if File.exist?(file)
+    end
+  end
+
   it 'does not directly encode the keys into the implementation file' do
     source = File.read(File.join(@tmpdir, 'Pods/CocoaPodsKeys/TestProjectKeys.m'))
     expect(source).to_not include('such-data')

--- a/spec/keyring_liberator_spec.rb
+++ b/spec/keyring_liberator_spec.rb
@@ -21,6 +21,13 @@ describe KeyringLiberator do
     expect(KeyringLiberator.get_keyring_named('test')).to equal(keyring)
   end
 
+  it 'should find many by name' do
+    keyring1 = Keyring.from_hash('name' => 'test', 'path' => 'testpath1', 'keys' => [])
+    keyring2 = Keyring.from_hash('name' => 'test', 'path' => 'testpath2', 'keys' => [])
+    allow(KeyringLiberator).to receive(:get_all_keyrings).and_return([keyring1, keyring2])
+    expect(KeyringLiberator.get_all_keyrings_named('test')).to eq([keyring1, keyring2])
+  end
+
   it 'should be nil if nothing found find by name' do
     keyring = Keyring.from_hash('name' => 'test', 'path' => 'testpath', 'keys' => [])
     allow(KeyringLiberator).to receive(:get_all_keyrings).and_return([keyring])

--- a/spec/keyring_spec.rb
+++ b/spec/keyring_spec.rb
@@ -9,7 +9,7 @@ class FakeKeychain
   end
 
   def [](_, key)
-    data[key]
+    @data[key]
   end
 end
 
@@ -31,7 +31,7 @@ describe KeyringLiberator do
     keyring = Keyring.new('test', '/', ['ARMyKey'])
     keyring.instance_variable_set(:@keychain, FakeKeychain.new('KeychainKey' => 'abcde'))
     expect(keyring.keychain_has_key?('KeychainKey')).to be_truthy
-    expect(keyring.keychain_value('KeychainKey')).to eq('12345')
+    expect(keyring.keychain_value('KeychainKey')).to eq('abcde')
     expect(keyring.keychain_has_key?('NotMyKey')).to be_falsey
   end
 
@@ -53,8 +53,8 @@ describe KeyringLiberator do
     keyring.keychain_has_key?('EnvKey')
     keyring.keychain_has_key?('NotMyKey')
 
-    expect(keyring.keys).to include?('KeychainKey')
-    expect(keyring.keys).to include?('EnvKey')
-    expect(keyring.keys).not_to include?('NotMyKey')
+    expect(keyring.keys.include?('KeychainKey')).to be_truthy
+    expect(keyring.keys.include?('EnvKey')).to be_truthy
+    expect(keyring.keys.include?('NotMyKey')).to be_falsey
   end
 end

--- a/spec/keyring_spec.rb
+++ b/spec/keyring_spec.rb
@@ -3,6 +3,16 @@ require 'keyring'
 
 include CocoaPodsKeys
 
+class FakeKeychain
+  def initialize(data)
+    @data = data
+  end
+
+  def [](_, key)
+    data[key]
+  end
+end
+
 describe KeyringLiberator do
   before(:each) do
     ENV['ARMyKey'] = 'Hello'
@@ -15,5 +25,36 @@ describe KeyringLiberator do
   it 'can get keys from ENV' do
     keyring = Keyring.new('test', '/', ['ARMyKey'])
     expect(keyring.keychain_data).to eq('ARMyKey' => 'Hello')
+  end
+
+  it 'looks up keys from the OSXKeychain' do
+    keyring = Keyring.new('test', '/', ['ARMyKey'])
+    keyring.instance_variable_set(:@keychain, FakeKeychain.new('KeychainKey' => 'abcde'))
+    expect(keyring.keychain_has_key?('KeychainKey')).to be_truthy
+    expect(keyring.keychain_value('KeychainKey')).to eq('12345')
+    expect(keyring.keychain_has_key?('NotMyKey')).to be_falsey
+  end
+
+  it 'looks up keys from ENV' do
+    keyring = Keyring.new('test', '/', ['ARMyKey'])
+    ENV['EnvKey'] = '12345'
+    keyring.instance_variable_set(:@keychain, FakeKeychain.new('KeychainKey' => 'abcde'))
+    expect(keyring.keychain_has_key?('EnvKey')).to be_truthy
+    expect(keyring.keychain_value('EnvKey')).to eq('12345')
+    expect(keyring.keychain_has_key?('NotMyKey')).to be_falsey
+  end
+
+  it 'updates its list of keys' do
+    keyring = Keyring.new('test', '/', ['NotMyKey'])
+    ENV['EnvKey'] = '12345'
+    keyring.instance_variable_set(:@keychain, FakeKeychain.new('KeychainKey' => 'abcde'))
+
+    keyring.keychain_has_key?('KeychainKey')
+    keyring.keychain_has_key?('EnvKey')
+    keyring.keychain_has_key?('NotMyKey')
+
+    expect(keyring.keys).to include?('KeychainKey')
+    expect(keyring.keys).to include?('EnvKey')
+    expect(keyring.keys).not_to include?('NotMyKey')
   end
 end


### PR DESCRIPTION
I was keeping two copies of my project around so that I could verify bugs in a separate Xcode window than the one where I'm working on a new feature (obv a separate branch would do the same, but would require full recompiles, which takes 2-3 days when compiling Swift files).

I added a key to the "main" project, and kept getting the error "CocoaPods-Keys has detected a keys mismatch for your setup."  Looking into it, it was because `get_keyring_named` was returning the wrong Keyring.

So here are two ideas: one, check the path.  Brittle if the user renames their project folder.  Two, emit a warning (error?) if two keyrings have the same name.

Both of these dodge the issue of what to DO when two projects have the same name!  In the actual keychain entries will be shared between the two projects, which is probably what is intended...

So, I wonder, if `yaml_path_for_path` should be based on the project name, but that would be a breaking change.  Ug.

Thoughts?
