### PR TITLE
Add support for loading environment `.env` file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     cocoapods-keys (1.5.0)
+      dotenv
       osx_keychain
 
 GEM
@@ -47,6 +48,7 @@ GEM
     cocoapods-try (0.4.3)
     colored (1.2)
     diff-lcs (1.2.5)
+    dotenv (2.0.2)
     escape (0.0.4)
     fuzzy_match (2.0.4)
     i18n (0.7.0)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ CocoaPods-keys has 3 other commands:
 
 #### Continuous Integration
 
-It's rarely a good idea to mess around with the keychain in your CI, so keys will look for an environment var with the same string before looking in the keychain.
+It's rarely a good idea to mess around with the keychain in your CI, so keys will look for an environment var with the same string before looking in the keychain. Also you could create a `.env` file in your project folder.
 
 #### Security
 

--- a/cocoapods_keys.gemspec
+++ b/cocoapods_keys.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "osx_keychain"
+  spec.add_runtime_dependency "dotenv"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -11,11 +11,13 @@ module CocoaPodsKeys
       require 'keyring_liberator'
       require 'pod/command/keys/set'
       require 'cocoapods/user_interface'
+      require 'dotenv'
 
       ui = Pod::UserInterface
 
       options = @user_options || {}
       current_dir = Pathname.pwd
+      Dotenv.load
       project = options.fetch('project') { CocoaPodsKeys::NameWhisperer.get_project_name }
 
       keyring = KeyringLiberator.get_current_keyring(project, current_dir)


### PR DESCRIPTION
Fixes #105

With this PR you could create a `.env` file in your project folder for all secret files.
So it's easier to share credentials in the team.