### PR TITLE
Adds export command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Adds `export` command to export keys in consumable way [ashfurrow]
+
 ## 1.5.2
 
 * Don't ask for input in CI [x2on]

--- a/lib/pod/command/keys.rb
+++ b/lib/pod/command/keys.rb
@@ -7,6 +7,7 @@ module Pod
       require 'pod/command/keys/set'
       require 'pod/command/keys/get'
       require 'pod/command/keys/rm'
+      require 'pod/command/keys/export'
 
       self.summary = 'A key value store for environment settings in Cocoa Apps.'
 

--- a/lib/pod/command/keys/export.rb
+++ b/lib/pod/command/keys/export.rb
@@ -1,0 +1,30 @@
+require 'keyring_liberator'
+
+module Pod
+  class Command
+    class Keys
+      class Export < Keys
+        self.summary = 'Exports commands to recreate the key setup.'
+
+        self.description = <<-DESC
+          Gives a list of all the pod keys commands necessary to recreate the key setup on another machine.
+        DESC
+
+        def run
+          # List all settings for current app
+          this_keyring = get_current_keyring
+          raise 'Could not load keyring' unless this_keyring
+          export_current_keyring this_keyring
+        end
+
+        def export_current_keyring(keyring)
+          data = keyring.keychain_data
+          data.each do |key, value|
+            UI.puts "pod keys set #{key} \"#{value}\" #{keyring.name}"
+          end
+          UI.puts
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_spec.rb
+++ b/spec/functional_spec.rb
@@ -49,6 +49,17 @@ describe 'CocoaPodsKeys functional tests' do
     end
   end
 
+  it 'is able to export the correct keys from the command-line' do
+    Dir.chdir(@tmpdir) do
+      exported_keys = <<-EOS
+pod keys set KeyWithData "such-data" TestProject
+pod keys set AnotherKeyWithData "other-data" TestProject
+pod keys set UnusedKey "-" TestProject
+EOS
+      expect(`pod keys export`.strip).to eq(exported_keys.strip)
+    end
+  end
+
   describe 'with a built keys implementation' do
     before :all do
       name = 'TestProjectKeys'


### PR DESCRIPTION
Usage is documented; it works like this:

```
> pod keys export
pod keys set ArtsyAPIClientSecret - Eidolon
pod keys set ArtsyAPIClientKey - Eidolon
pod keys set HockeyProductionSecret - Eidolon
pod keys set HockeyBetaSecret - Eidolon
pod keys set MixpanelProductionAPIClientKey - Eidolon
pod keys set MixpanelStagingAPIClientKey - Eidolon
pod keys set CardflightStagingAPIClientKey - Eidolon
pod keys set CardflightStagingMerchantAccountToken - Eidolon
pod keys set StripeStagingPublishableKey - Eidolon
pod keys set CardflightProductionAPIClientKey - Eidolon
pod keys set CardflightProductionMerchantAccountToken - Eidolon
pod keys set StripeProductionPublishableKey - Eidolon
```

Where the `-` is actually the real key (they're all OSS keys in this example). Now we can copy+paste this output into 1Password and use it to set up new machines.

Fixes #118.