### PR TITLE
Keys that have been removed from the project weren't being deleted from the YML file.

### DIFF
--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -31,6 +31,15 @@ module CocoaPodsKeys
 
       has_shown_intro = false
       keys = options.fetch('keys', [])
+      
+      # Remove keys from the keyring that no longer exist
+      original_keyring_keys = keyring.keys.clone
+      original_keyring_keys.each do |key|
+        keyring.keychain_has_key?(key)
+      end
+      
+      # Add keys to the keyring that have been added,
+      # and prompt for their value if needed.
       keys.each do |key|
         unless keyring.keychain_has_key?(key)
           unless has_shown_intro

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -31,13 +31,13 @@ module CocoaPodsKeys
 
       has_shown_intro = false
       keys = options.fetch('keys', [])
-      
+
       # Remove keys from the keyring that no longer exist
       original_keyring_keys = keyring.keys.clone
       original_keyring_keys.each do |key|
         keyring.keychain_has_key?(key)
       end
-      
+
       # Add keys to the keyring that have been added,
       # and prompt for their value if needed.
       keys.each do |key|


### PR DESCRIPTION
For example, if a key is removed from the Podfile, then running `pod install` results in the removed key still being present in the yml file, and thus still getting added to the generated *.h/m files.