### PR TITLE
Fixed usage link

### DIFF
--- a/SWIFT_PROJECTS.md
+++ b/SWIFT_PROJECTS.md
@@ -1,6 +1,6 @@
 # Using Cocoapods-Keys in Swift projects
 
-Once you've followed the setup instructions described in the [Usage](/orta/cocoapods-keys#usage)
+Once you've followed the setup instructions described in the [Usage](README.md#usage)
 section of the README, you have two choices.
 
 ## Importing the framework


### PR DESCRIPTION
The usage link to the readme ended up being a 404. Not entirely sure if this is the best way to write relative links on Github, but it works :/