### PR TITLE
Enhance Swift usage docs

### DIFF
--- a/SWIFT_PROJECTS.md
+++ b/SWIFT_PROJECTS.md
@@ -18,3 +18,9 @@ import Keys
 let keys = MyApplicationKeys()
 ARAnalytics.setupWithAnalytics(keys.analyticsToken)
 ```
+
+### Troubleshooting
+
+You can get into a situation where you have an existing integrated project but when you add a new key it isn't recognized in the file(s) you `import Keys` in, although your project is configured properly (you can check by verifying it's shown with a `pod keys` and/or manually viewing the generated `*.h/*.m` files). 
+
+The fix: close Xcode, `rm -rf Pods/` to clear your pods installation, and then **also** clear out your Xcode's Derived Data finder folder. Running a fresh `pod install` should generate a proper swift class in the Keys module.

--- a/SWIFT_PROJECTS.md
+++ b/SWIFT_PROJECTS.md
@@ -23,4 +23,4 @@ ARAnalytics.setupWithAnalytics(keys.analyticsToken)
 
 You can get into a situation where you have an existing integrated project but when you add a new key it isn't recognized in the file(s) you `import Keys` in, although your project is configured properly (you can check by verifying it's shown with a `pod keys` and/or manually viewing the generated `*.h/*.m` files). 
 
-The fix: close Xcode, `rm -rf Pods/` to clear your pods installation, and then **also** clear out your Xcode's Derived Data finder folder. Running a fresh `pod install` should generate a proper swift class in the Keys module.
+The fix: clear out your Xcode's Derived Data finder folder and rebuilding should generate a proper swift class in the Keys module.


### PR DESCRIPTION
I was just about to open a new issue 

> i have an existing project setup with cocoapods-keys and the relevant swift file imports `Keys` just fine with all of the initial keys (setup through the interactive configuration from the first `pod install`) are there, but a new key added later on is not found.

> i took a peek, and the generated `*h/*m` files include the new key, as well as a `pod keys` output -- but the generated swift `public class SuperSpecialSecretKeys : NSObject { ...` class is missing it.

> cocoapods version 1.0.1

when I thought to clear out Xcode's derived data folder––problem solved. I don't quickly think to clear that finder folder, not sure if others do when strangeness happens, but updated the swift-related docs to include this situation for future instances.