### PR TITLE
Adding "--output-directory" option for the generate command.

### DIFF
--- a/lib/pod/command/keys/generate.rb
+++ b/lib/pod/command/keys/generate.rb
@@ -12,6 +12,17 @@ module Pod
           Generates the obfuscated Objective-C h/m files using the current key values.
         DESC
 
+        def self.options
+          [
+            ['--output-directory=/output/dir', 'Allows override of .h/.m file output']
+          ].concat(super)
+        end
+
+        def initialize(argv)
+          @output_directory = argv.option('output-directory')
+          super
+        end
+
         def run
           Dotenv.load
           keyring = get_current_keyring
@@ -21,7 +32,7 @@ module Pod
             # Create the h & m files in the same folder as the podspec
 
             installation_root = Pod::Config.instance.installation_root
-            keys_path = installation_root.+('Pods/CocoaPodsKeys/')
+            keys_path = @output_directory || installation_root.+('Pods/CocoaPodsKeys/')
 
             key_master = CocoaPodsKeys::KeyMaster.new(keyring)
             interface_file = keys_path + (key_master.name + '.h')


### PR DESCRIPTION
Motivation:

We're using cocoapods-keys in a project, and we automatically generate the .h/.m files during the build process (via a build script). This allows the developer to change key/value pairs as needed, and a simple "Build-and-Run" will automatically "do the right thing".

I.E. if they've changed a key/value pair, then simply compiling in Xcode, will automatically re-generate the corresponding XKeys.m file with the updated value. This helps reduce the cognitive overhead of using the system for the development team:

Steps before:
- update value in .env file
- don't forget to run 'pod install' !
- build-and-go in Xcode

Steps after:
- update value in .env file
- build-and-go in Xcode

Although this currently works, it's less than optimal, as modifying the .h/.m files everytime results in recompiling several files every build. This added feature allows the user to direct the generated .h/.m files elsewhere. Which enables use of diff tool, and thus can avoid overwriting files unnecessarily.

Once this pull request is merged, I can also add a wiki page that demonstrates:

- An example script that runs the 'pod keys generate' command.
- How to automatically integrate it via the Podfile and post_install hook.