### PR TITLE
Converted key methods to properties 

### DIFF
--- a/templates/Keys.h.erb
+++ b/templates/Keys.h.erb
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface <%= @name %> : NSObject
 <% @keys.each do |key, value| %>
-- (NSString *)<%= key %>;<% end %>
+@property (readonly) NSString *<%= key %>;<% end %>
 
 @end
 

--- a/templates/Keys.m.erb
+++ b/templates/Keys.m.erb
@@ -12,7 +12,6 @@
 #pragma clang diagnostic ignored "-Wincomplete-implementation"
 
 @implementation <%= @name %>
-
 <% @keys.each do |key, value| %>
   @dynamic <%= key %>;<% end %>
 

--- a/templates/Keys.m.erb
+++ b/templates/Keys.m.erb
@@ -13,6 +13,9 @@
 
 @implementation <%= @name %>
 
+<% @keys.each do |key, value| %>
+  @dynamic <%= key %>;<% end %>
+
 #pragma clang diagnostic pop
 
 + (BOOL)resolveInstanceMethod:(SEL)name


### PR DESCRIPTION
`@dynamic` in .h file added to prevent Objective C generating default ivar and a getter which ruins runtime magic in `resolveInstanceMethod`.