### PR TITLE
Raise when asking for keys on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Don't ask for keys on the command line when running on CI. [dantoml]
+
 ## 1.7.0
 
 * Fixes undefined method '*' for nil:NilClass issue on first run [rpassis]

--- a/lib/preinstaller.rb
+++ b/lib/preinstaller.rb
@@ -42,6 +42,10 @@ module CocoaPodsKeys
       # and prompt for their value if needed.
       keys.each do |key|
         unless keyring.keychain_has_key?(key)
+          if ENV['CI']
+            raise Informative, "CocoaPods-Keys could not find a key named: #{key}"
+          end
+
           unless has_shown_intro
             ui.puts "\n CocoaPods-Keys has detected a keys mismatch for your setup."
             has_shown_intro = true


### PR DESCRIPTION
I frequently see new projects on CI that will timeout waiting for user input when missing key env vars.

It probably makes sense to do this in other places that ask for user input too?