### PR TITLE
Add missing 'project_name' param to generate command

### DIFF
--- a/lib/pod/command/keys/generate.rb
+++ b/lib/pod/command/keys/generate.rb
@@ -10,7 +10,16 @@ module Pod
 
         self.description = <<-DESC
           Generates the obfuscated Objective-C h/m files using the current key values.
+
+          An optional operator can be done to force a project name.
         DESC
+
+        self.arguments = [CLAide::Argument.new('project_name', false)]
+
+        def initialize(argv)
+          @project_name = argv.shift_argument
+          super
+        end
 
         def run
           Dotenv.load


### PR DESCRIPTION
The parameter was listed in the README but not implemented.

This PR should allow the generation of key files without user intervention on projects with multiple Xcode projects files.