### PR TITLE
🐛 Fixes #180 and add other missing platforms

### DIFF
--- a/templates/Keys.podspec.json
+++ b/templates/Keys.podspec.json
@@ -18,10 +18,10 @@
     "tag": "23"
   },
   "platforms": {
-    "ios": "8.0",
-    "osx": "10.10",
-    "watchos": "8.3",
-    "tvos": "8.3"
+    "ios": "5.0",
+    "osx": "10.7",
+    "watchos": "2.0",
+    "tvos": "9.0"
   },
   "source_files": "*.{h,m,swift}",
   "frameworks": "Foundation",


### PR DESCRIPTION
This fixes #180 by adding the missing platforms with proper minimal requirements.

Cocoapods-Keys does not use any API introduced after iOS 2.0, but requires ARC (introduced
in 5.0). It does not, as far as I'm aware, require iOS 8.0. So this should also fix broken
builds for apps targeting iOS 5, 6 and 7.

WatchOS 8.3 does not exist. The current version is 4.3, although this plugin is compatible
with 2.0.

TvOS 8.3 also never existed. The original version was 9.0.

For OS X/macOS, there is no dependency on Yosemite (10.10). ARC was introduced in Lion
(10.7).

**Note:** This PR does _not_ address #182, as sanitizing the tests will require more
work.