### PR TITLE
Fix for duplicate keyrings in Jenkins

### DIFF
--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -47,7 +47,7 @@ module CocoaPodsKeys
 
     def self.save_keyring(keyring)
       keys_dir.mkpath
-      if !ENV['TRAVIS'] && !ENV['TEAMCITY_VERSION'] && !ENV['CIRCLECI'] && !ENV['JENKINS_HOME']
+      if ci?
         prompt_if_already_existing(keyring)
       end
       yaml_path_for_path(keyring.path).open('w') { |f| f.write(YAML.dump(keyring.to_hash)) }
@@ -67,5 +67,12 @@ module CocoaPodsKeys
     end
 
     private_class_method :get_keyring_at_path
+
+    def ci?
+      %w([JENKINS_HOME TRAVIS CIRCLECI CI TEAMCITY_VERSION GO_PIPELINE_NAME bamboo_buildKey GITLAB_CI XCS]).each do |current|
+        return true if ENV.key?(current)
+      end
+      false
+    end
   end
 end

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -68,7 +68,7 @@ module CocoaPodsKeys
 
     private_class_method :get_keyring_at_path
 
-    def ci?
+    def self.ci?
       %w([JENKINS_HOME TRAVIS CIRCLECI CI TEAMCITY_VERSION GO_PIPELINE_NAME bamboo_buildKey GITLAB_CI XCS]).each do |current|
         return true if ENV.key?(current)
       end

--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -47,7 +47,7 @@ module CocoaPodsKeys
 
     def self.save_keyring(keyring)
       keys_dir.mkpath
-      if !ENV['TRAVIS'] && !ENV['TEAMCITY_VERSION'] && !ENV['CIRCLECI']
+      if !ENV['TRAVIS'] && !ENV['TEAMCITY_VERSION'] && !ENV['CIRCLECI'] && !ENV['JENKINS_HOME']
         prompt_if_already_existing(keyring)
       end
       yaml_path_for_path(keyring.path).open('w') { |f| f.write(YAML.dump(keyring.to_hash)) }


### PR DESCRIPTION
I noticed some timeouts in Jenkins with the following format:

```
[15:37:12]: $ bundle exec pod install
[15:43:17]: ▸ About to create a duplicate keyring file for project REDACTED
[15:43:17]: ▸ Entries in your Apple Keychain will be shared between both projects.
[15:43:17]: ▸ Press enter to continue, or `ctrl + c` to cancel
```

The script is waiting for input, but since we’re on CI that isn't practical. I found this message in the project in `keyring_liberator.rb` and noticed that the list of environment variables it uses to determine if it's running in CI is different than in `preinstaller.rb`, so I copied the latter's list into the former.

I'm not super great with Ruby, so I didn't attempt to make both files pull this method from the same source file, but that would be the obvious improvement here.