### PR TITLE
Fix for running on CI with duplicate keyring names

### DIFF
--- a/lib/keyring_liberator.rb
+++ b/lib/keyring_liberator.rb
@@ -47,7 +47,7 @@ module CocoaPodsKeys
 
     def self.save_keyring(keyring)
       keys_dir.mkpath
-      if ci?
+      unless ci?
         prompt_if_already_existing(keyring)
       end
       yaml_path_for_path(keyring.path).open('w') { |f| f.write(YAML.dump(keyring.to_hash)) }


### PR DESCRIPTION
The way the code is structured now it only prompts on CI, when it should be the reverse; it should _not_ prompt on CI.