### PR TITLE
Store only unique keys in the keyring

### DIFF
--- a/lib/pod/command/keys/set.rb
+++ b/lib/pod/command/keys/set.rb
@@ -40,6 +40,7 @@ module Pod
 
           keyring = get_current_keyring || create_keyring
           keyring.keys << @key_name.tr('-', '_')
+          keyring.keys.uniq!
           CocoaPodsKeys::KeyringLiberator.save_keyring keyring
 
           keyring.save @key_name, @key_value


### PR DESCRIPTION
As of now, every time a new key is set, it gets appended to the list of keys on the yaml file and if it already exists for that keyring, it will get duplicated. I can't think of any serious consequences that this may cause, but after a while the yaml file becomes messy and the output of `pod keys` too. In other words, this is just 💅, but hopefully you guys like it. 🙂 