### PR TITLE
Add fallback keys option to generate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Master
 
+* Add the ability to manually specify keys when running `pod keys generate`. [fwal]
+
 ## 2.0.7
 
 * Fix keys not recorded in YML on first run. [ileitch]

--- a/lib/pod/command/keys/generate.rb
+++ b/lib/pod/command/keys/generate.rb
@@ -16,14 +16,19 @@ module Pod
 
         self.arguments = [CLAide::Argument.new('project_name', false)]
 
+        def self.options
+          [['--keys=key1,key2...', 'An array of keys to add if no keyring is found']].concat(super)
+        end
+
         def initialize(argv)
           @project_name = argv.shift_argument
+          @keys = argv.option('keys', '').split(',')
           super
         end
 
         def run
           Dotenv.load
-          keyring = get_current_keyring
+          keyring = get_current_keyring || CocoaPodsKeys::Keyring.new(@project_name, '/', @keys)
 
           if keyring
 


### PR DESCRIPTION
### The problem

When running in CI, we've opted to just run the `pod keys generate` command rather than `pod install` to generate the obfuscated objc files. However, as we're using ENV keys to set the values there aren't any keyring yaml files that contains the name of the keys and as such the command doesn't know the name of the ENV variables to look for.

### The solution

Add an option `--keys` to the generate command that's used to create a runtime keyring if no existing keyring could be found, letting the system know which keys to look for.

```
export Foo=foo
export Bar=bar

pod keys generate --keys=Foo,Bar
```