### PR TITLE
Fix C inlining issues

### DIFF
--- a/lib/key_master.rb
+++ b/lib/key_master.rb
@@ -84,7 +84,7 @@ module CocoaPodsKeys
     end
 
     def key_data_arrays
-      Hash[@indexed_keys.map { |key, value| [key, value.map { |i| "[" + name + "Data characterAtIndex:#{i}]" }.join(', ')] }]
+      Hash[@indexed_keys.map { |key, value| [key, value.map { |i| '[' + name + "Data characterAtIndex:#{i}]" }.join(', ')] }]
     end
   end
 end

--- a/lib/key_master.rb
+++ b/lib/key_master.rb
@@ -84,7 +84,7 @@ module CocoaPodsKeys
     end
 
     def key_data_arrays
-      Hash[@indexed_keys.map { |key, value| [key, value.map { |i| name + "Data[#{i}]" }.join(', ')] }]
+      Hash[@indexed_keys.map { |key, value| [key, value.map { |i| "[" + name + "Data characterAtIndex:#{i}]" }.join(', ')] }]
     end
   end
 end

--- a/templates/Keys.m.erb
+++ b/templates/Keys.m.erb
@@ -4,49 +4,37 @@
 // For more information see https://github.com/orta/cocoapods-keys
 //
 
-#import <objc/runtime.h>
 #import <Foundation/NSDictionary.h>
 #import "<%= @name %>.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wincomplete-implementation"
+@interface <%= @name %> ()
+
+<% @keys.each do |key, value| %>@property (nonatomic, copy) NSString *<%= key %>;
+<% end %>
+
+@end
 
 @implementation <%= @name %>
-<% @keys.each do |key, value| %>
-  @dynamic <%= key %>;<% end %>
 
-#pragma clang diagnostic pop
-
-+ (BOOL)resolveInstanceMethod:(SEL)name
+- (instancetype)init
 {
-  NSString *key = NSStringFromSelector(name);
-  NSString * (*implementation)(<%= name %> *, SEL) = NULL;
-<% @keys.each do |key, value| %>
-  if ([key isEqualToString:@"<%= key %>"]) {
-    implementation = _podKeys<%= Digest::MD5.hexdigest(key) %>;
-  }
-<% end %>
-  if (!implementation) {
-    return [super resolveInstanceMethod:name];
-  }
+    if (!(self = [super init])) { return nil; }
 
-  return class_addMethod([self class], name, (IMP)implementation, "@@:");
-}
-<% @keys.each do |key, value| %>
-static NSString *_podKeys<%= Digest::MD5.hexdigest(key) %>(<%= name %> *self, SEL _cmd)
-{
-  <% if @indexed_keys.length > 0 %>
-    <% if @indexed_keys[key].length > 0 %>
-      char cString[<%= @indexed_keys[key].length + 1 %>] = { <%= key_data_arrays[key] %>, '\0' };
-    <% else %>
-      char cString[1] = { '\0' };
+    <% @keys.each do |key, value| %>
+    char <%= key %>CString[<%= @indexed_keys[key].length + 1 %>] = { <%= key_data_arrays[key] %>, '\0' };
+    _<%= key %> = <% if @indexed_keys.length > 0 %>
+        <% if @indexed_keys[key].length > 0 %>
+          [NSString stringWithCString:<%= key %>CString encoding:NSUTF8StringEncoding];
+        <% else %>
+          @"";
+        <% end %>
+      <% else %>
+        @"";
+      <% end %>
     <% end %>
-    return [NSString stringWithCString:cString encoding:NSUTF8StringEncoding];
-  <% else %>
-    return @"";
-  <% end %>
+    
+    return self;
 }
-<% end %>
 
 static NSString *<%= name %>Data = @"<%= @data.gsub('\\', '\\\\\\').gsub('"', '\\"') if @data %>";
 

--- a/templates/Keys.m.erb
+++ b/templates/Keys.m.erb
@@ -48,7 +48,7 @@ static NSString *_podKeys<%= Digest::MD5.hexdigest(key) %>(<%= name %> *self, SE
 }
 <% end %>
 
-static char <%= name %>Data[<%= @data_length %>] = "<%= @data.gsub('\\', '\\\\\\').gsub('"', '\\"') if @data %>";
+static NSString *<%= name %>Data = @"<%= @data.gsub('\\', '\\\\\\').gsub('"', '\\"') if @data %>";
 
 - (NSString *)description
 {


### PR DESCRIPTION
I've tested this with Artsy's codebase to make sure it still works 👍 It puts the data in an NSString, and uses `characterAtIndex:` Objective-C function calls, which are unlikely to be inlined by the compile. This might incur some performance penalty, but, that's probably fine.

I also made some refactors to use less Objective-C runtime stuff and make this easier to maintain. The downside of this approach is that it loads _all_ keys upfront in `init`, which has potential further performance impacts. This now optimizes for creating fewer instances of the `Keys` object, since creating each one is more expensive but each key access is free. 

The refactor is in a separate commit in case you'd like to keep the original implementation. I have verified both commits solve the problem of inlining keys in the binaries.

Fixes #201.