### PR TITLE
Fixes CI #trivial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ spec/fixtures/dump-key
 vendor
 install
 .bundle
+*.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cocoapods-keys (2.1.0)
+    cocoapods-keys (2.2.1)
       dotenv
       osx_keychain
 
@@ -9,9 +9,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (2.3.5)
-    RubyInline (3.12.4)
+    RubyInline (3.12.5)
       ZenTest (~> 4.3)
-    ZenTest (4.11.2)
+    ZenTest (4.12.0)
     activesupport (4.2.9)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -53,7 +53,7 @@ GEM
     colored (1.2)
     colored2 (3.1.2)
     diff-lcs (1.3)
-    dotenv (2.6.0)
+    dotenv (2.7.5)
     escape (0.0.4)
     fourflusher (0.3.2)
     fuzzy_match (2.0.4)
@@ -116,4 +116,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://travis-ci.org/orta/cocoapods-keys.svg)
+[![Build Status](https://travis-ci.org/orta/cocoapods-keys.svg?branch=master)](https://travis-ci.org/orta/cocoapods-keys)
 
 A key value store for enviroment and application keys.
 


### PR DESCRIPTION
This is mostly just running `bundle install` to update the `Gemfile.lock` file ([example failing build](https://travis-ci.org/github/orta/cocoapods-keys/builds/704808391)). Also did some cleanup.

This is trivial, so I'm going to self-assign.