### PR TITLE
Use keyword argument like ERB.new(str, trim_mode: ...) instead

### DIFF
--- a/lib/key_master.rb
+++ b/lib/key_master.rb
@@ -80,7 +80,7 @@ module CocoaPodsKeys
 
     def render_erb(erb_template)
       erb = (Pathname(__dir__).parent + 'templates' + erb_template).read
-      ERB.new(erb, nil, '-').result(binding)
+      ERB.new(erb, trim_mode: '-').result(binding)
     end
 
     def key_data_arrays


### PR DESCRIPTION
Fix #229 

I fixed these two warnings

- `Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.`
- `Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.`